### PR TITLE
Preparations for an intermediate release 0.81

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project (statismo)
 
 ENABLE_TESTING()
 
-SET(STATISMO_VERSION 0.9) 
-SET(STATISMO_MINOR_VERSION 0)
+SET(STATISMO_VERSION 0.8) 
+SET(STATISMO_MINOR_VERSION 1)
 
 
 # rpath settings
@@ -109,7 +109,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/statismo_ITK DESTINATION include)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Representers DESTINATION include)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/statismo-config.cmake.in  ${CMAKE_CURRENT_BINARY_DIR}/statismo-config.cmake @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/statismo-config.cmake DESTINATION lib/cmake/statismo-${STATISMO_VERSION})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/statismo-config.cmake DESTINATION lib/cmake/statismo-${STATISMO_VERSION}${STATISMO_MINOR_VERSION})
 
 # 
 # copy the data

--- a/statismo/Config.h
+++ b/statismo/Config.h
@@ -41,7 +41,7 @@
 #include <string>
 
 namespace statismo {
-const std::string STATISMO_VERSION = "0.9";
+const std::string STATISMO_VERSION = "0.81";
 }
 
 // gccxml (as used by e.g. wrapitk) does not compile with vectorization enabled.


### PR DESCRIPTION
In the upcoming release 0.9, it is planned to simplify the installation procedure and the concept of the representer. This will include quite some changes in the code, and also at some points slightly change the interface. 
Before pushing these changes to the master, we should tag and release our improvements since 0.8, such that people can still use them without having to change their application immediately to the new API.
