### PR TITLE
Added two defines for MSVC11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,13 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${STATISMO_LIBRARY_DIR}")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+IF(MSVC11) #i.e. Visual Studio 2012 
+  # Fix for VS2012 that has _VARIADIC_MAX set to 5. Don't set too high because it increases compiler memory usage / compile-time.
+  add_definitions( -D_VARIADIC_MAX=10 )
+  # Fix for another VS2012 problem: not all TR1 options are automatically detected, therefore we force them here.
+  ADD_DEFINITIONS( -D BOOST_HAS_TR1 )
+ENDIF()
+
 #
 #optional examples and wrapping
 option(BUILD_ITK_EXAMPLES "Build the itk examples " OFF)


### PR DESCRIPTION
Added two defines for Microsoft Visual Studio 11 (2012). 
_VARIADIC_MAX=10 was proposed by Patrick Huber, because the default 5 is too small.

BOOST_HAS_TR1 seems to be needed for Boost to not interfere with the MSVC11 implementation of std::tr1
