### PR TITLE
Make ReduceVarianceModelBuilder work correctly when scores are not set (Issue #57) 

### DIFF
--- a/Tests/statismoTests/TestModelBuilders.py
+++ b/Tests/statismoTests/TestModelBuilders.py
@@ -392,7 +392,7 @@ class Test(unittest.TestCase):
         reducedVarianceModelBuilder = statismo.ReducedVarianceModelBuilder_vtkPD.Create()
 
         ncomponentsToKeep = model.GetNumberOfPrincipalComponents() / 2
-        newModelWithNComponents = reducedVarianceModelBuilder.BuildNewModelWithLeadingComponents(model, ncomponentsToKeep, True)
+        newModelWithNComponents = reducedVarianceModelBuilder.BuildNewModelWithLeadingComponents(model, ncomponentsToKeep)
         self.assertTrue(newModelWithNComponents.GetNumberOfPrincipalComponents() == ncomponentsToKeep)
 
         for percentOfTotalVar in [1.0, 0.9, 0.8, 0.7, 0.6, 0.4, 0.2, 0.1]:
@@ -408,6 +408,20 @@ class Test(unittest.TestCase):
         # check that there is a reduction (though we cannot say how much, as the specified variance is a lower bound)
         reducedModel05 = reducedVarianceModelBuilder.BuildNewModelWithVariance(model, 0.5)
         self.assertTrue(reducedModel05.GetPCAVarianceVector().sum() <= model.GetPCAVarianceVector().sum())        
+
+
+    def testReducedVarianceModelBuilderHandlesModelWithoutScores(self):
+        # check that a model can also be reduced when no scores are present
+        modelbuilder = statismo.PCAModelBuilder_vtkPD.Create()
+
+        model = modelbuilder.BuildNewModel(self.dataManager.GetData(), 0., False)
+        reducedVarianceModelBuilder = statismo.ReducedVarianceModelBuilder_vtkPD.Create()
+
+        ncomponentsToKeep = model.GetNumberOfPrincipalComponents() / 2
+        newModelWithNComponents = reducedVarianceModelBuilder.BuildNewModelWithLeadingComponents(model, ncomponentsToKeep)
+        self.assertTrue(newModelWithNComponents.GetNumberOfPrincipalComponents() == ncomponentsToKeep)
+        self.assertTrue(newModelWithNComponents.GetModelInfo().GetScoresMatrix().shape[0] == 0)
+
 
 
 

--- a/Wrapping/SWIG/statismo.i
+++ b/Wrapping/SWIG/statismo.i
@@ -461,9 +461,9 @@ public:
 	static ReducedVarianceModelBuilder* Create();
 	virtual ~ReducedVarianceModelBuilder();
 
-        StatisticalModelType* BuildNewModelWithLeadingComponents(const StatisticalModelType* model, unsigned numberOfLeadingComponents, bool computeScores=true) const;
-        StatisticalModelType* BuildNewModelWithVariance(const StatisticalModelType* model,	double totalVariance, bool computeScores=true) const;
-	StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model,	double totalVariance, bool computeScores=true) const;
+        StatisticalModelType* BuildNewModelWithLeadingComponents(const StatisticalModelType* model, unsigned numberOfLeadingComponents) const;
+        StatisticalModelType* BuildNewModelWithVariance(const StatisticalModelType* model,	double totalVariance) const;
+        StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model,	double totalVariance) const;
 
 	private:
 		ReducedVarianceModelBuilder();

--- a/statismo/ReducedVarianceModelBuilder.h
+++ b/statismo/ReducedVarianceModelBuilder.h
@@ -87,26 +87,26 @@ public:
      *
      * \param model A statistical model.
      * \param numberOfPrincipalComponents,
-     * \param computeScores Determines whether the scores are computed and stored in the model.
      * \return a new statistical model
      *
      * \warning The returned model needs to be explicitly deleted by the user of this method.
      */
-    StatisticalModelType* BuildNewModelWithLeadingComponents(const StatisticalModelType* model, unsigned numberOfPrincipalComponents, bool computeScores = true) const;
+    StatisticalModelType* BuildNewModelWithLeadingComponents(const StatisticalModelType* model, unsigned numberOfPrincipalComponents) const;
+
 
     /**
      * Build a new model from the given model, which retains only the specified variance
      *
      * \param model A statistical model.
      * \param totalVariance, The fraction of the variance to be retained
-     * \param computeScores Determines whether the scores are computed and stored in the model.
      * \return a new statistical model
      *
      * \warning The returned model needs to be explicitly deleted by the user of this method.
      */
-    StatisticalModelType* BuildNewModelWithVariance(const StatisticalModelType* model, double totalVariance, bool computeScores=true) const;
+    StatisticalModelType* BuildNewModelWithVariance(const StatisticalModelType* model, double totalVariance) const;
 
-    is_deprecated StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model, double totalVariance, bool computeScores=true) const ;
+
+    is_deprecated StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model, double totalVariance) const ;
 
 
 private:

--- a/statismo/ReducedVarianceModelBuilder.txx
+++ b/statismo/ReducedVarianceModelBuilder.txx
@@ -59,8 +59,7 @@ template <typename T>
 typename ReducedVarianceModelBuilder<T>::StatisticalModelType*
 ReducedVarianceModelBuilder<T>::BuildNewModelWithLeadingComponents(
         const StatisticalModelType* inputModel,
-        unsigned numberOfPrincipalComponents,
-        bool computeScores) const
+        unsigned numberOfPrincipalComponents) const
 
 {
     StatisticalModelType* reducedModel = StatisticalModelType::Create(
@@ -81,19 +80,24 @@ ReducedVarianceModelBuilder<T>::BuildNewModelWithLeadingComponents(
   BuilderInfo builderInfo("ReducedVarianceModelBuilder", di, bi);
   builderInfoList.push_back(builderInfo);
 
-  ModelInfo info(inputModel->GetModelInfo().GetScoresMatrix().topRows(numberOfPrincipalComponents), builderInfoList);
+  // If the scores matrix is not set, or if we have for some reasons not as many score entries as the number of principal components,
+  // we simply work with what is there.
+  unsigned numComponentsForScores = std::min(static_cast<unsigned>(inputModel->GetModelInfo().GetScoresMatrix().rows()), numberOfPrincipalComponents);
+
+  ModelInfo info(inputModel->GetModelInfo().GetScoresMatrix().topRows(numComponentsForScores), builderInfoList);
   reducedModel->SetModelInfo(info);
 
   return reducedModel;
 
 }
 
+
+
 template <typename T>
 typename ReducedVarianceModelBuilder<T>::StatisticalModelType*
 ReducedVarianceModelBuilder<T>::BuildNewModelWithVariance(
 		const StatisticalModelType* inputModel,
-		double totalVariance,
-		bool computeScores) const
+        double totalVariance) const
 {
 
 	VectorType pcaVariance = inputModel->GetPCAVarianceVector();
@@ -108,18 +112,17 @@ ReducedVarianceModelBuilder<T>::BuildNewModelWithVariance(
 		  if (cumulatedVariance / modelVariance >= totalVariance)
 			  break;
       }
-    return BuildNewModelWithLeadingComponents(inputModel, numComponentsToReachPrescribedVariance, computeScores);
+    return BuildNewModelWithLeadingComponents(inputModel, numComponentsToReachPrescribedVariance);
 }
 
 template <typename T>
 typename ReducedVarianceModelBuilder<T>::StatisticalModelType*
     ReducedVarianceModelBuilder<T>::BuildNewModelFromModel(
             const StatisticalModelType* inputModel,
-            double totalVariance,
-            bool computeScores) const
+            double totalVariance) const
 {
 
-       return BuildNewModelWithVariance(inputModel, totalVariance, computeScores);
+       return BuildNewModelWithVariance(inputModel, totalVariance);
 }
 
 

--- a/statismo_ITK/itkReducedVarianceModelBuilder.h
+++ b/statismo_ITK/itkReducedVarianceModelBuilder.h
@@ -90,25 +90,25 @@ public:
 
 
 
-    typename StatisticalModel<Representer>::Pointer BuildNewModelWithLeadingComponents(const StatisticalModel<Representer>* model, unsigned numberOfPrincipalComponents, bool computeScores=true) {
+    typename StatisticalModel<Representer>::Pointer BuildNewModelWithLeadingComponents(const StatisticalModel<Representer>* model, unsigned numberOfPrincipalComponents) {
         statismo::StatisticalModel<Representer>* model_statismo = model->GetstatismoImplObj();
-        statismo::StatisticalModel<Representer>* new_model_statismo = callstatismoImpl(std::tr1::bind(&ImplType::BuildNewModelWithLeadingComponents, this->m_impl, model_statismo, numberOfPrincipalComponents, computeScores));
+        statismo::StatisticalModel<Representer>* new_model_statismo = callstatismoImpl(std::tr1::bind(&ImplType::BuildNewModelWithLeadingComponents, this->m_impl, model_statismo, numberOfPrincipalComponents));
         typename StatisticalModel<Representer>::Pointer model_itk = StatisticalModel<Representer>::New();
         model_itk->SetstatismoImplObj(new_model_statismo);
         return model_itk;
     }
 
-    typename StatisticalModel<Representer>::Pointer BuildNewModelWithVariance(const StatisticalModel<Representer>* model, double totalVariance, bool computeScores=true) {
+    typename StatisticalModel<Representer>::Pointer BuildNewModelWithVariance(const StatisticalModel<Representer>* model, double totalVariance) {
         statismo::StatisticalModel<Representer>* model_statismo = model->GetstatismoImplObj();
-        statismo::StatisticalModel<Representer>* new_model_statismo = callstatismoImpl(std::tr1::bind(&ImplType::BuildNewModelWithVariance, this->m_impl, model_statismo, totalVariance, computeScores));
+        statismo::StatisticalModel<Representer>* new_model_statismo = callstatismoImpl(std::tr1::bind(&ImplType::BuildNewModelWithVariance, this->m_impl, model_statismo, totalVariance));
         typename StatisticalModel<Representer>::Pointer model_itk = StatisticalModel<Representer>::New();
         model_itk->SetstatismoImplObj(new_model_statismo);
         return model_itk;
     }
 
-    is_deprecated typename StatisticalModel<Representer>::Pointer BuildNewModelFromModel(const StatisticalModel<Representer>* model, double totalVariance, bool computeScores=true) {
+    is_deprecated typename StatisticalModel<Representer>::Pointer BuildNewModelFromModel(const StatisticalModel<Representer>* model, double totalVariance) {
 		statismo::StatisticalModel<Representer>* model_statismo = model->GetstatismoImplObj();
-		statismo::StatisticalModel<Representer>* new_model_statismo = callstatismoImpl(std::tr1::bind(&ImplType::BuildNewModelFromModel, this->m_impl, model_statismo, totalVariance, computeScores));
+        statismo::StatisticalModel<Representer>* new_model_statismo = callstatismoImpl(std::tr1::bind(&ImplType::BuildNewModelFromModel, this->m_impl, model_statismo, totalVariance));
 		typename StatisticalModel<Representer>::Pointer model_itk = StatisticalModel<Representer>::New();
 		model_itk->SetstatismoImplObj(new_model_statismo);
 		return model_itk;


### PR DESCRIPTION
In addition to the bugfix, this commit also removes the default argument computeScores, as it was ignored anyway.
