### PR TITLE
Switch to Boost 1.55 (fixes #95)

### DIFF
--- a/superbuild/External-Boost.cmake
+++ b/superbuild/External-Boost.cmake
@@ -23,8 +23,8 @@ set( Boost_Patch_Command ${SHELL_CMD} ${Boost_Patch_Script} )
 
 ExternalProject_Add(Boost
   BUILD_IN_SOURCE 1
-  URL "http://sourceforge.net/projects/boost/files/boost/1.54.0/boost_1_54_0.tar.gz"
-  URL_MD5 efbfbff5a85a9330951f243d0a46e4b9
+  URL "http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz"
+  URL_MD5 93780777cfbf999a600f62883bd54b17
   UPDATE_COMMAND ""
   PATCH_COMMAND ${Boost_Patch_Command}
   CONFIGURE_COMMAND ${Boost_Bootstrap_Command} --prefix=${INSTALL_DEPECENCIES_DIR}/lib --with-libraries=thread --with-libraries=system

--- a/superbuild/patches/boost/boost_patch.sh
+++ b/superbuild/patches/boost/boost_patch.sh
@@ -1,4 +1,1 @@
-curl http://www.boost.org/patches/1_54_0/001-coroutine.patch | patch -p1
-curl http://www.boost.org/patches/1_54_0/002-date-time.patch | patch -p1
-curl http://www.boost.org/patches/1_54_0/003-log.patch | patch -p1
-curl http://www.boost.org/patches/1_54_0/004-thread.patch | patch -p1
+#curl http://www.boost.org/patches/1_55_0/001-log_fix_dump_avx2.patch | patch -p1


### PR DESCRIPTION
Fix for #95. 

@arnaudgelas I tried to apply the patches as you did for boost 1.54. However it fails for some reasons. Can you have a look? Apart from that, everything works fine on Ubuntu 14.04.  
