### PR TITLE
Ugly hack to ensure that boost .bat files are formatted with DOS line endings

### DIFF
--- a/superbuild/patches/boost/boost_patch.sh
+++ b/superbuild/patches/boost/boost_patch.sh
@@ -1,1 +1,13 @@
+#!/bin/sh
+
 #curl http://www.boost.org/patches/1_55_0/001-log_fix_dump_avx2.patch | patch -p1
+
+if [ `echo "x$OS" | grep -c Windows` -eq 1 ]; then
+	# Boost ships some .bat files with Unix line endings, which confuses
+	# cmd.exe in some circumstances, and causes an
+	# "input line is too long" error, resulting in a failed build.
+	#
+	# This is an ugly hack to work around that issue.
+	find . -name "*.bat" -print0 | xargs -0 -I{} unix2dos {}
+fi
+


### PR DESCRIPTION
Tested and working. Any comments?

PS: This actually requires that Windows be able to execute .sh files (for instance by installing Git for Windows), but if I'm not mistaken, that has always been the case. I'm just wondering if that is documented.
