### PR TITLE
Replaced import statismo_VTK in python tests

### DIFF
--- a/modules/VTK/wrapping/tests/statismoTests/TestDataManager.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestDataManager.py
@@ -39,7 +39,7 @@ import tempfile
 import os.path
 import vtk
 
-import statismo
+import statismo_VTK as statismo
 from statismoTestUtils import DATADIR, getDataFiles, read_vtkpd
 
 class Test(unittest.TestCase):

--- a/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
@@ -39,7 +39,7 @@ from os import listdir
 from os.path import join
 from scipy import zeros, randn, log, isnan, any, sqrt, identity
 
-import statismo
+import statismo_VTK as statismo
 
 from statismoTestUtils import getDataFiles, DATADIR, getPDPointWithId, read_vtkpd
 import tempfile

--- a/modules/VTK/wrapping/tests/statismoTests/TestStatisticalModel.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestStatisticalModel.py
@@ -39,7 +39,7 @@ from os import listdir
 from os.path import join
 from scipy import zeros, randn, log, eye
 from scipy.stats import norm as normdist
-import statismo
+import statismo_VTK as statismo
 
 from statismoTestUtils import buildPolyDataModel, DATADIR, getPDPointWithId
 import tempfile

--- a/modules/VTK/wrapping/tests/statismoTests/statismoTestUtils.py
+++ b/modules/VTK/wrapping/tests/statismoTests/statismoTestUtils.py
@@ -35,7 +35,7 @@
 #
 #
 
-import statismo
+import statismo_VTK as statismo
 import os
 from os import listdir
 from os.path import join, realpath


### PR DESCRIPTION
The same as https://github.com/statismo/statismo/pull/135#event-189391218 
Btw, the first time I tried in a linux server (after changing manually some paths) and I could see the tests running succesfully. I've tried on my windows installation and it crashes during the load/save tests. 
