### PR TITLE
ConditionalModelBuuilder.hxx: replaced topLeftCorner with leftCols

### DIFF
--- a/modules/core/include/ConditionalModelBuilder.hxx
+++ b/modules/core/include/ConditionalModelBuilder.hxx
@@ -208,7 +208,7 @@ ConditionalModelBuilder<T>::BuildNewModel(const DataItemListType& sampleDataList
         unsigned numComponentsToKeep = std::min<unsigned>( numComponentsToReachPrescribedVariance, singularValues.size() );
 
         VectorType newPCAVariance = singularValues.topRows(numComponentsToKeep);
-        MatrixType newPCABasisMatrix = (pcaModel->GetOrthonormalPCABasisMatrix() * svd.matrixU().cast<ScalarType>()).topLeftCorner(X.cols(), numComponentsToKeep);
+        MatrixType newPCABasisMatrix = (pcaModel->GetOrthonormalPCABasisMatrix() * svd.matrixU().cast<ScalarType>()).leftCols(numComponentsToKeep);
 
         StatisticalModelType* model = StatisticalModelType::Create(pcaModel->GetRepresenter(),  condMeanSample, newPCABasisMatrix, newPCAVariance, noiseVariance);
 


### PR DESCRIPTION
fixes #157 
avoid assert errors due to incompatible matrix dimensions
