### PR TITLE
Fix #160

### DIFF
--- a/cmake/ModuleHeaderTest.cmake
+++ b/cmake/ModuleHeaderTest.cmake
@@ -19,7 +19,7 @@ add_custom_target( StatismoHeaderTests
   ${CMAKE_COMMAND} --build ${statismo_BINARY_DIR}
   COMMENT "Regenerating and building the header tests." )
 
-macro( module_headertest _name )
+function( module_headertest _name )
   if( NOT ${BUILD_TESTING} )
     return()
   endif()
@@ -98,4 +98,4 @@ macro( module_headertest _name )
       math( EXPR _test_num "${_test_num} + 1" )
     endforeach()
   endif()
-endmacro()
+endfunction()


### PR DESCRIPTION
Looking at 'return()' documentation in cmake, i.e.

$ cmake --help-command return
## return

Return from a file, directory or function.

::

 return()

Returns from a file, directory or function.  When this command is
encountered in an included file (via include() or find_package()), it
causes processing of the current file to stop and control is returned
to the including file.  If it is encountered in a file which is not
included by another file, e.g.  a CMakeLists.txt, control is returned
to the parent directory if there is one.  If return is called in a
function, control is returned to the caller of the function.  Note
that a macro is not a function and does not handle return like a
function does.

call to 'return()' in a macro explains the error, it would return after each call
and files would never get installed.

instead of using a macro, we now use a function.

Co-Authored-By: Stefan Schlager zarquon42@gmail.com
