### PR TITLE
Replace tmpname by boost::unique_path. Fixes #173.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,11 +87,11 @@ if( WIN32 )
   set( Boost_USE_STATIC_LIBS ON )
 endif()
 
-find_package( Boost 1.50 COMPONENTS thread system date_time REQUIRED )
+find_package( Boost 1.50 COMPONENTS thread system date_time filesystem REQUIRED )
 include_directories( ${Boost_INCLUDE_DIRS} )
 
 link_directories( ${Boost_LIBRARY_DIRS} )
-add_definitions( -DBOOST_THREAD_VERSION=3 )
+add_definitions( -DBOOST_THREAD_VERSION=3 -DBOOST_FILESYSTEM_VERSION=3 )
 
 find_package( HDF5  COMPONENTS C CXX)
 include_directories( ${HDF5_INCLUDE_DIRS} )

--- a/modules/ITK/include/itkStandardImageRepresenter.hxx
+++ b/modules/ITK/include/itkStandardImageRepresenter.hxx
@@ -51,6 +51,8 @@
 #include <itkPoint.h>
 #include <itkVector.h>
 
+#include <boost/filesystem.hpp>
+
 #include "HDF5Utils.h"
 #include "StatismoUtils.h"
 
@@ -187,11 +189,12 @@ StandardImageRepresenter<TPixel, ImageDimension>::LoadRefLegacy(const H5::Group&
     try {
         reader->Update();
     } catch (itk::ImageFileReaderException& e) {
+      boost::filesystem::remove(tmpfilename);
         throw statismo::StatisticalModelException((std::string("Could not read file ") + tmpfilename).c_str());
     }
     typename DatasetType::Pointer img = reader->GetOutput();
     img->Register();
-    std::remove(tmpfilename.c_str());
+    boost::filesystem::remove(tmpfilename);
     return img;
 
 }

--- a/modules/ITK/include/itkStandardMeshRepresenter.hxx
+++ b/modules/ITK/include/itkStandardMeshRepresenter.hxx
@@ -49,6 +49,8 @@
 #include <itkTransformMeshFilter.h>
 #include <itkVector.h>
 
+#include <boost/filesystem.hpp>
+
 #include "HDF5Utils.h"
 #include "StatismoUtils.h"
 
@@ -179,11 +181,12 @@ StandardMeshRepresenter<TPixel, MeshDimension>::LoadRefLegacy(const H5::Group& f
     try {
         reader->Update();
     } catch (itk::MeshFileReaderException& e) {
+      boost::filesystem::remove(tmpfilename);
         throw statismo::StatisticalModelException((std::string("Could not read file ") + tmpfilename).c_str());
     }
 
     typename MeshType::Pointer mesh = reader->GetOutput();
-    std::remove(tmpfilename.c_str());
+    boost::filesystem::remove(tmpfilename);
     return mesh;
 
 }

--- a/modules/VTK/include/vtkStandardImageRepresenter.hxx
+++ b/modules/VTK/include/vtkStandardImageRepresenter.hxx
@@ -43,6 +43,8 @@
 #include <vtkDataArray.h>
 #include <vtkVersion.h>
 
+#include <boost/filesystem.hpp>
+
 #include "CommonTypes.h"
 #include "HDF5Utils.h"
 #include "StatismoUtils.h"
@@ -264,6 +266,7 @@ vtkStructuredPoints* vtkStandardImageRepresenter<TScalar, PixelDimensions>::Load
     vtkStructuredPointsReader* reader = vtkStructuredPointsReader::New();
     reader->SetFileName(tmpfilename.c_str());
     reader->Update();
+    boost::filesystem::remove(tmpfilename);
     if (reader->GetErrorCode() != 0) {
         throw StatisticalModelException((std::string("Could not read file ") + tmpfilename).c_str());
     }

--- a/modules/VTK/src/vtkStandardMeshRepresenter.cxx
+++ b/modules/VTK/src/vtkStandardMeshRepresenter.cxx
@@ -54,6 +54,8 @@
 #include <vtkUnsignedLongArray.h>
 #include <vtkUnsignedShortArray.h>
 
+#include <boost/filesystem.hpp>
+
 #include "HDF5Utils.h"
 #include "StatismoUtils.h"
 
@@ -177,6 +179,7 @@ vtkPolyData* vtkStandardMeshRepresenter::LoadRefLegacy(const H5::Group& fg) cons
     vtkPolyDataReader* reader = vtkPolyDataReader::New();
     reader->SetFileName(tmpfilename.c_str());
     reader->Update();
+    boost::filesystem::remove(tmpfilename);
     if (reader->GetErrorCode() != 0) {
         throw StatisticalModelException((std::string("Could not read file ") + tmpfilename).c_str());
     }

--- a/modules/core/include/StatismoUtils.h
+++ b/modules/core/include/StatismoUtils.h
@@ -134,7 +134,7 @@ class Utils {
 
     static std::string CreateTmpName(const std::string& extension) {
       boost::filesystem::path temp = boost::filesystem::unique_path();
-      const std::string tempstr    = temp.native();
+      const std::string tempstr    = temp.string();
       return tempstr;
     }
 

--- a/modules/core/include/StatismoUtils.h
+++ b/modules/core/include/StatismoUtils.h
@@ -46,6 +46,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <boost/filesystem.hpp>
 
 #ifdef _WIN32
 #define NOMINMAX // avoid including the min and max macro
@@ -132,22 +133,9 @@ class Utils {
 
 
     static std::string CreateTmpName(const std::string& extension) {
-#ifdef _WIN32
-        std::string tmpDirectoryName;
-        TCHAR szTempFileName[MAX_PATH];
-        DWORD dwRetVal = 0;
-        //  Gets the temp path env string (no guarantee it's a valid path).
-        dwRetVal = GetTempPath(MAX_PATH,          // length of the buffer
-                               szTempFileName); // buffer for path
-        tmpDirectoryName.assign(szTempFileName);
-        std::string tmpfilename = tmpDirectoryName + "/" + tmpnam(0) +extension;
-        return tmpfilename;
-#else
-        std::string tmpfilename = tmpnam(0);
-        tmpfilename += extension;
-        return tmpfilename;
-#endif
-
+      boost::filesystem::path temp = boost::filesystem::unique_path();
+      const std::string tempstr    = temp.native();
+      return tempstr;
     }
 
 };

--- a/statismoConfig.cmake.in
+++ b/statismoConfig.cmake.in
@@ -13,6 +13,7 @@ set( Boost_INCLUDE_DIR @Boost_INCLUDE_DIR@ )
 set( Boost_LIBRARY_DIRS @Boost_LIBRARY_DIRS@ )
 set( Boost_LIBRARIES @Boost_LIBRARIES@ )
 add_definitions( -DBOOST_THREAD_VERSION=3 )
+add_definitions( -DBOOST_FILESYSTEM_VERSION=3 
 
 set( HDF5_DIR @HDF5_DIR@ )
 set( HDF5_INCLUDE_DIRS @HDF5_INCLUDE_DIRS@ )

--- a/statismoConfig.cmake.in
+++ b/statismoConfig.cmake.in
@@ -13,7 +13,7 @@ set( Boost_INCLUDE_DIR @Boost_INCLUDE_DIR@ )
 set( Boost_LIBRARY_DIRS @Boost_LIBRARY_DIRS@ )
 set( Boost_LIBRARIES @Boost_LIBRARIES@ )
 add_definitions( -DBOOST_THREAD_VERSION=3 )
-add_definitions( -DBOOST_FILESYSTEM_VERSION=3 
+add_definitions( -DBOOST_FILESYSTEM_VERSION=3 )
 
 set( HDF5_DIR @HDF5_DIR@ )
 set( HDF5_INCLUDE_DIRS @HDF5_INCLUDE_DIRS@ )

--- a/superbuild/External-Boost.cmake
+++ b/superbuild/External-Boost.cmake
@@ -35,7 +35,7 @@ ExternalProject_Add(Boost
   URL_MD5 ${Boost_md5}
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ${Boost_Bootstrap_Command} --prefix=${INSTALL_DEPENDENCIES_DIR}/lib
-  BUILD_COMMAND ${Boost_b2_Command} install -j8   --prefix=${INSTALL_DEPENDENCIES_DIR} --with-thread --with-system --with-date_time address-model=${Boost_address_model}
+  BUILD_COMMAND ${Boost_b2_Command} install -j8   --prefix=${INSTALL_DEPENDENCIES_DIR} --with-thread --with-filesystem --with-system --with-date_time address-model=${Boost_address_model}
   INSTALL_COMMAND ""
 )
 


### PR DESCRIPTION
The price to pay for this fix is that we now depend also on boost::filesystem. 
However, as we already make use of several boost libraries, this does not add much new complexity. 