### PR TITLE
Added support of SelfAdjointEigenSolver for the PCAModelBuilder .

### DIFF
--- a/modules/ITK/include/itkPCAModelBuilder.h
+++ b/modules/ITK/include/itkPCAModelBuilder.h
@@ -71,6 +71,8 @@ class PCAModelBuilder : public Object {
     typedef statismo::DataManager<Representer> DataManagerType;
     typedef typename DataManagerType::DataItemListType DataItemListType;
 
+    typedef typename ImplType::EigenValueMethod EigenValueMethod;
+
     PCAModelBuilder() : m_impl(ImplType::Create()) {}
 
     virtual ~PCAModelBuilder() {
@@ -91,8 +93,8 @@ class PCAModelBuilder : public Object {
 
 
 
-    typename StatisticalModel<Representer>::Pointer BuildNewModel(DataItemListType DataItemList, float noiseVariance, bool computeScores = true) {
-        statismo::StatisticalModel<Representer>* model_statismo = callstatismoImpl(boost::bind(&ImplType::BuildNewModel, this->m_impl, DataItemList, noiseVariance, computeScores));
+    typename StatisticalModel<Representer>::Pointer BuildNewModel(DataItemListType DataItemList, float noiseVariance, bool computeScores = true, EigenValueMethod method = ImplType::JacobiSVD) {
+        statismo::StatisticalModel<Representer>* model_statismo = callstatismoImpl(boost::bind(&ImplType::BuildNewModel, this->m_impl, DataItemList, noiseVariance, computeScores, method));
         typename StatisticalModel<Representer>::Pointer model_itk = StatisticalModel<Representer>::New();
         model_itk->SetstatismoImplObj(model_statismo);
         return model_itk;

--- a/modules/VTK/tests/CMakeLists.txt
+++ b/modules/VTK/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set( _VTKTests
   PosteriorModelBuilderTest
+  PCAModelBuilderWithSelfAdjointEigenSolverTest
   vtkStandardImageRepresenterTest
   vtkStandardMeshRepresenterTest
 )
@@ -11,6 +12,9 @@ endforeach()
 
 add_test( NAME PosteriorModelBuilderTest
   COMMAND PosteriorModelBuilderTest ${statismo_SOURCE_DIR}/data
+)
+add_test( NAME PCAModelBuilderWithSelfAdjointEigenSolverTest
+  COMMAND PCAModelBuilderWithSelfAdjointEigenSolverTest ${statismo_SOURCE_DIR}/data
 )
 add_test( NAME vtkStandardImageRepresenterTest
   COMMAND vtkStandardImageRepresenterTest ${statismo_SOURCE_DIR}/data

--- a/modules/VTK/tests/PCAModelBuilderWithSelfAdjointEigenSolverTest.cxx
+++ b/modules/VTK/tests/PCAModelBuilderWithSelfAdjointEigenSolverTest.cxx
@@ -1,0 +1,307 @@
+/*
+ * This file is part of the statismo library.
+ *
+ * Author: Christoph Jud (christoph.jud@unibas.ch)
+ *
+ * Copyright (c) 2015 University of Basel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the project's author nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <boost/scoped_ptr.hpp>
+#include <ctime>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+#include <vtkMath.h>
+#include <vtkPoints.h>
+#include <vtkPolyDataReader.h>
+#include <vtkPolyDataWriter.h>
+#include <vtkVersion.h>
+
+#include "CommonTypes.h"
+#include "DataManager.h"
+#include "Domain.h"
+#include "genericRepresenterTest.hxx"
+#include "PCAModelBuilder.h"
+#include "vtkStandardMeshRepresenter.h"
+
+using namespace statismo;
+
+typedef GenericRepresenterTest<vtkStandardMeshRepresenter> RepresenterTestType;
+
+vtkPolyData* loadPolyData(const std::string& filename) {
+    vtkPolyDataReader* reader = vtkPolyDataReader::New();
+    reader->SetFileName(filename.c_str());
+    reader->Update();
+    vtkPolyData* pd = vtkPolyData::New();
+    pd->ShallowCopy(reader->GetOutput());
+    reader->Delete();
+    return pd;
+}
+
+void writePolyData(vtkPolyData* pd, const std::string& filename) {
+    vtkSmartPointer< vtkPolyDataWriter > writer = vtkSmartPointer< vtkPolyDataWriter >::New();
+    writer->SetFileName(filename.c_str());
+#if (VTK_MAJOR_VERSION == 5 )
+    writer->SetInput(pd);
+#else
+    writer->SetInputData(pd);
+#endif
+    writer->Update();
+}
+
+vtkPolyData* ReducePoints(vtkPolyData* poly, unsigned num_points){
+    vtkPoints* points = vtkPoints::New();
+    unsigned step = unsigned(std::ceil(double(poly->GetPoints()->GetNumberOfPoints())/double(num_points)));
+    for(unsigned i=0; i<poly->GetPoints()->GetNumberOfPoints(); i+=step){
+        points->InsertNextPoint(poly->GetPoints()->GetPoint(i));
+    }
+    vtkPolyData* res = vtkPolyData::New();
+    res->SetPoints(points);
+    return res;
+}
+
+double CompareVectors(const VectorType& v1, const VectorType& v2){
+    return (v1-v2).norm();
+}
+
+double CompareMatrices(const MatrixType& m1, const MatrixType& m2){
+    return (m1-m2).norm();
+}
+
+/**
+ * The test works as follows:
+ *  - First a standard PCA model is built out of the sample hand-shapes of statismo
+ *    It is ensured that the standard argument results in exactly the same model
+ *    as if JacobiSVD is provided.
+ *  - In the second test, a PCA model is built out of 5000 samples drawn from the
+ *    previous built model. Here, the SelfAdjointEigenSolver is used, since there
+ *    are more samples than variables.
+ *
+ * Arguments:
+ *  - one can provide a number of points with which the samples should be subsampled (default is 100)
+ *  - additionally, one can provide an output directory. If this is provided, the principal
+ *    components of the model are sampled and stored in this directory. This is meant for visual inspection.
+ */
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " datadir " << "[number_of_points=100] [output_dir]" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    std::string datadir = std::string(argv[1]);
+
+    bool testsOk = true;
+
+    // number of points which are used for building the model
+    // the number of points is reduced since the SelfAdjointEigenSolver operates
+    // on the full covariance matrix. So
+    unsigned num_points = 100;
+    if(argc==3) num_points = std::atoi(argv[2]);
+
+    std::string output_dir = "";
+    if(argc==4) output_dir = argv[3];
+
+    std::vector<std::string> filenames;
+    filenames.push_back(datadir+"/hand_polydata/hand-0.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-1.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-2.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-3.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-4.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-5.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-6.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-7.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-8.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-9.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-10.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-11.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-12.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-13.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-14.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-15.vtk");
+    filenames.push_back(datadir+"/hand_polydata/hand-16.vtk");
+
+
+    typedef vtkStandardMeshRepresenter RepresenterType;
+    typedef statismo::DataManager<vtkPolyData> DataManagerType;
+    typedef vtkStandardMeshRepresenter::PointType PointType;
+    typedef vtkStandardMeshRepresenter::DomainType DomainType;
+    typedef DomainType::DomainPointsListType DomainPointsListType;
+    typedef statismo::StatisticalModel<vtkPolyData> StatisticalModelType;
+
+
+    vtkPolyData* reference = loadPolyData(filenames[0]);
+    reference = ReducePoints(reference, num_points);
+    RepresenterType* representer = RepresenterType::Create(reference);
+
+    boost::scoped_ptr<DataManagerType> dataManager(DataManagerType::Create(representer));
+
+    std::vector<std::string>::const_iterator it = filenames.begin();
+    for(; it!=filenames.end(); it++){
+        vtkPolyData* testDataset = loadPolyData((*it));
+        testDataset = ReducePoints(testDataset, num_points);
+        dataManager->AddDataset(testDataset, "dataset");
+    }
+
+
+    // ----------------------------------------------------------
+    // First compute PCA model using standard JacobiSVD
+    // ----------------------------------------------------------
+    std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "building PCA model with JacobiSVD... " << std::flush;
+    std::clock_t begin = std::clock();
+    double data_noise = 0;
+    typedef statismo::PCAModelBuilder<vtkPolyData> PCAModelBuilderType;
+    PCAModelBuilderType* pcaModelBuilder = PCAModelBuilderType::Create();
+    StatisticalModelType* jacobiModel;
+
+    // perform with standard argument
+    jacobiModel = pcaModelBuilder->BuildNewModel(dataManager->GetData(),data_noise,false);
+    VectorType variance1 = jacobiModel->GetPCAVarianceVector();
+    MatrixType pcbasis1 = jacobiModel->GetPCABasisMatrix();
+
+    // perform with providing JacobiSVD
+    jacobiModel = pcaModelBuilder->BuildNewModel(dataManager->GetData(),data_noise,false, PCAModelBuilderType::JacobiSVD);
+
+    VectorType variance2 = jacobiModel->GetPCAVarianceVector();
+    MatrixType pcbasis2 = jacobiModel->GetPCABasisMatrix();
+
+    if(CompareVectors(variance1, variance2)==0 && CompareMatrices(pcbasis1, pcbasis2) == 0){
+        std::clock_t end = std::clock();
+        std::cout << " (" << double(end - begin) / CLOCKS_PER_SEC << " sec) \t\t[passed]" << std::endl;
+    }
+    else{
+        std::cout << " \t[failed]" << std::endl;
+        std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t\t\t" << "- something went wrong with the standard argument!" << std::endl;
+        testsOk = false;
+    }
+
+
+    // ----------------------------------------------------------
+    // Generate a lot of samples out of the JacobiSVD model
+    // ----------------------------------------------------------
+    boost::scoped_ptr<DataManagerType> dataManager2(DataManagerType::Create(representer));
+    dataManager->AddDataset(reference, "ref");
+    for(unsigned i=0; i<5000; i++){
+        std::stringstream ss;
+        ss << "sample" << i;
+        dataManager2->AddDataset(jacobiModel->DrawSample(), ss.str().c_str());
+    }
+
+
+    // ----------------------------------------------------------
+    // Compute PCA model using the SelfAdjointEigenSolver
+    // ----------------------------------------------------------
+    std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "building PCA model with SelfAdjointEigenSolver... " << std::flush;
+    begin = std::clock();
+    StatisticalModelType* saesModel = pcaModelBuilder->BuildNewModel(dataManager2->GetData(),data_noise,false, PCAModelBuilderType::SelfAdjointEigenSolver);
+    std::clock_t end = std::clock();
+    std::cout << " (" << double(end - begin) / CLOCKS_PER_SEC << " sec) \t[passed]" << std::endl;
+
+
+    // ----------------------------------------------------------
+    // Comparing the models
+    // - compare each principal component
+    // ----------------------------------------------------------
+    std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "comparing principal components... " << std::flush;
+    begin = std::clock();
+    double error = 0;
+    for(unsigned i=0; i<std::min(jacobiModel->GetNumberOfPrincipalComponents(), saesModel->GetNumberOfPrincipalComponents()); i++){
+        VectorType coeff1 = VectorType::Zero(jacobiModel->GetNumberOfPrincipalComponents());
+        coeff1[i] = 2;
+        VectorType coeff2 = VectorType::Zero(saesModel->GetNumberOfPrincipalComponents());
+        coeff2[i] = 2;
+
+        // it might be, that the direction of the pc is in the opposite direction
+        double equal_direction = CompareVectors(jacobiModel->DrawSampleVector(coeff1, false),
+                                        saesModel->DrawSampleVector(coeff2, false));
+        coeff2[i] = -2;
+        double oppo_direction = CompareVectors(jacobiModel->DrawSampleVector(coeff1, false),
+                                        saesModel->DrawSampleVector(coeff2, false));
+
+        error += std::min(equal_direction, oppo_direction);
+
+        if(output_dir.size() >0){
+            std::stringstream ss1;
+            ss1 << output_dir << "/jacobi-" << i << ".vtk";
+            writePolyData(jacobiModel->DrawSample(coeff1, false), ss1.str().c_str());
+
+            std::stringstream ss2;
+            ss2 << output_dir << "/saes-" << i << ".vtk";
+            if(equal_direction<oppo_direction) coeff2[i] = 2;
+            writePolyData(saesModel->DrawSample(coeff2, false), ss2.str().c_str());
+        }
+    }
+
+    double threshold = 150;
+    if(error < threshold){
+        std::clock_t end = std::clock();
+        std::cout << " (" << double(end - begin) / CLOCKS_PER_SEC << " sec) \t\t\t[passed]" << std::endl;
+    }
+    else{
+        std::cout << " \t[failed]" << std::endl;
+        std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "- pc error("<< error << ") exceeds threshold ("<< threshold <<")!" << std::endl;
+        testsOk = false;
+    }
+
+    double var_error = 0;
+    for(unsigned i=0; i<std::min(jacobiModel->GetNumberOfPrincipalComponents(), saesModel->GetNumberOfPrincipalComponents()); i++){
+        var_error += std::sqrt(std::pow(jacobiModel->GetPCAVarianceVector()[i] - saesModel->GetPCAVarianceVector()[i],2));
+    }
+
+    std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "comparing variances... " << std::flush;
+    double var_threshold = 250;
+    if(var_error < var_threshold){
+        std::clock_t end = std::clock();
+        std::cout << " (" << double(end - begin) / CLOCKS_PER_SEC << " sec) \t\t\t\t[passed]" << std::endl;
+    }
+    else{
+        std::cout << " \t[failed]" << std::endl;
+        std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "- variance error("<< var_error << ") exceeds threshold ("<< var_threshold <<")!" << std::endl;
+        testsOk = false;
+    }
+
+
+    if(output_dir.size() >0){
+        std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "The results can be visually inspected in the directory " << output_dir << std::endl;
+    }
+
+    if (testsOk == true) {
+        std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "Summary - tests passed." << std::endl;
+        return EXIT_SUCCESS;
+    } else {
+        std::cout << "PCAModelBuilderWithSelfAdjointEigenSolverTest: \t" << "Summary - tests failed." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+}
+
+
+

--- a/modules/VTK/wrapping/statismo.i
+++ b/modules/VTK/wrapping/statismo.i
@@ -394,10 +394,12 @@ public:
 	typedef typename DataManager<T> DataManagerType;
 	typedef typename DataManagerType::DataItemListType DataItemListType;	
 
+        typedef enum { JacobiSVD, SelfAdjointEigenSolver } EigenValueMethod;
+
 	%newobject Create;
 	static PCAModelBuilder* Create();
 	
-	 StatisticalModel<T>* BuildNewModel(const DataItemListType& sampleList, double noiseVariance, bool computeScores=true) const;	 
+         StatisticalModel<T>* BuildNewModel(const DataItemListType& sampleList, double noiseVariance, bool computeScores=true, EigenValueMethod method = JacobiSVD) const;
 private:
 	PCAModelBuilder();
 

--- a/modules/core/include/PCAModelBuilder.h
+++ b/modules/core/include/PCAModelBuilder.h
@@ -68,9 +68,9 @@ class PCAModelBuilder : public ModelBuilder<T> {
     typedef typename DataManagerType::DataItemListType DataItemListType;
 
     /**
-     * @brief The EigenValueMethod enum This type is used to specify which decomposition method resp. eigenvalue solver sould be used. Default is JacobiSVD which is the most accurate but for larger systems quite slow. In this case the SelfAdjointEigensolver is more appropriate (especially, if there are more examples than variables). If the system is still to large to solve, and only the first few eigenvalues/eigenvectors need to be computed the RandomSVD can be used as an approximation.
+     * @brief The EigenValueMethod enum This type is used to specify which decomposition method resp. eigenvalue solver sould be used. Default is JacobiSVD which is the most accurate but for larger systems quite slow. In this case the SelfAdjointEigensolver is more appropriate (especially, if there are more examples than variables).
      */
-    typedef enum { JacobiSVD, SelfAdjointEigenSolver, RandomSVD } EigenValueMethod;
+    typedef enum { JacobiSVD, SelfAdjointEigenSolver } EigenValueMethod;
 
     /**
      * Factory method to create a new PCAModelBuilder

--- a/modules/core/include/PCAModelBuilder.h
+++ b/modules/core/include/PCAModelBuilder.h
@@ -68,6 +68,11 @@ class PCAModelBuilder : public ModelBuilder<T> {
     typedef typename DataManagerType::DataItemListType DataItemListType;
 
     /**
+     * @brief The EigenValueMethod enum This type is used to specify which decomposition method resp. eigenvalue solver sould be used. Default is JacobiSVD which is the most accurate but for larger systems quite slow. In this case the SelfAdjointEigensolver is more appropriate (especially, if there are more examples than variables). If the system is still to large to solve, and only the first few eigenvalues/eigenvectors need to be computed the RandomSVD can be used as an approximation.
+     */
+    typedef enum { JacobiSVD, SelfAdjointEigenSolver, RandomSVD } EigenValueMethod;
+
+    /**
      * Factory method to create a new PCAModelBuilder
      */
     static PCAModelBuilder* Create() {
@@ -96,11 +101,12 @@ class PCAModelBuilder : public ModelBuilder<T> {
      * If this parameter is set to 0, we have a standard PCA model. For values > 0 we have a PPCA model.
      * \param computeScores Determines whether the scores (the pca coefficients of the examples) are computed and stored as model info
      * (computing the scores may take a long time for large models).
+     * \param method Specifies the method which is used for the decomposition resp. eigenvalue solver.
      *
      * \return A new Statistical model
      * \warning The method allocates a new Statistical Model object, that needs to be deleted by the user.
      */
-    StatisticalModelType* BuildNewModel(const DataItemListType& samples, double noiseVariance, bool computeScores = true) const;
+    StatisticalModelType* BuildNewModel(const DataItemListType& samples, double noiseVariance, bool computeScores = true, EigenValueMethod method = JacobiSVD) const;
 
 
   private:
@@ -109,7 +115,7 @@ class PCAModelBuilder : public ModelBuilder<T> {
     PCAModelBuilder(const PCAModelBuilder& orig);
     PCAModelBuilder& operator=(const PCAModelBuilder& rhs);
 
-    StatisticalModelType* BuildNewModelInternal(const Representer<T>* representer, const MatrixType& X, double noiseVariance) const;
+    StatisticalModelType* BuildNewModelInternal(const Representer<T>* representer, const MatrixType& X, double noiseVariance, EigenValueMethod method = JacobiSVD) const;
 
 
 };

--- a/modules/core/include/PCAModelBuilder.hxx
+++ b/modules/core/include/PCAModelBuilder.hxx
@@ -218,11 +218,6 @@ PCAModelBuilder<T>::BuildNewModelInternal(const Representer<T>* representer, con
     }
         break;
 
-    case RandomSVD:
-    {
-        throw StatisticalModelException("The RandomSVD is not jet supported in the PCAModelBuilder.");
-    }
-        break;
     default:
         throw StatisticalModelException("Unrecognized decomposition/eigenvalue solver method.");
         return 0;

--- a/modules/core/include/PCAModelBuilder.hxx
+++ b/modules/core/include/PCAModelBuilder.hxx
@@ -43,6 +43,7 @@
 #include <iostream>
 
 #include <Eigen/SVD>
+#include <Eigen/Eigenvalues>
 
 #include "CommonTypes.h"
 #include "Exceptions.h"
@@ -57,7 +58,7 @@ PCAModelBuilder<T>::PCAModelBuilder()
 
 template <typename T>
 typename PCAModelBuilder<T>::StatisticalModelType*
-PCAModelBuilder<T>::BuildNewModel(const DataItemListType& sampleDataList, double noiseVariance, bool computeScores) const {
+PCAModelBuilder<T>::BuildNewModel(const DataItemListType& sampleDataList, double noiseVariance, bool computeScores, EigenValueMethod method) const {
 
     unsigned n = sampleDataList.size();
     if (n <= 0) {
@@ -81,7 +82,7 @@ PCAModelBuilder<T>::BuildNewModel(const DataItemListType& sampleDataList, double
 
 
     // build the model
-    StatisticalModelType* model = BuildNewModelInternal(representer, X, noiseVariance);
+    StatisticalModelType* model = BuildNewModelInternal(representer, X, noiseVariance, method);
     MatrixType scores;
     if (computeScores) {
         scores = this->ComputeScores(X, model);
@@ -117,10 +118,7 @@ PCAModelBuilder<T>::BuildNewModel(const DataItemListType& sampleDataList, double
 
 template <typename T>
 typename PCAModelBuilder<T>::StatisticalModelType*
-PCAModelBuilder<T>::BuildNewModelInternal(const Representer<T>* representer, const MatrixType& X, double noiseVariance) const {
-
-    typedef Eigen::JacobiSVD<MatrixType> SVDType;
-    typedef Eigen::JacobiSVD<MatrixTypeDoublePrecision> SVDDoublePrecisionType;
+PCAModelBuilder<T>::BuildNewModelInternal(const Representer<T>* representer, const MatrixType& X, double noiseVariance, EigenValueMethod method) const {
 
     unsigned n = X.rows();
     unsigned p = X.cols();
@@ -128,65 +126,107 @@ PCAModelBuilder<T>::BuildNewModelInternal(const Representer<T>* representer, con
     RowVectorType mu = X.colwise().mean(); // needs to be row vector
     MatrixType X0 = X.rowwise() - mu;
 
-    // We destinguish the case where we have more variables than samples and
-    // the case where we have more samples than variable.
-    // In the first case we compute the (smaller) inner product matrix instead of the full covariance matrix.
-    // It is known that this has the same non-zero singular values as the covariance matrix.
-    // Furthermore, it is possible to compute the corresponding eigenvectors of the covariance matrix from the
-    // decomposition.
+    switch(method){
+    case JacobiSVD:
 
-    if (n < p) {
-        // we compute the eigenvectors of the covariance matrix by computing an SVD of the
-        // n x n inner product matrix 1/(n-1) X0X0^T
-        MatrixType Cov = X0 * X0.transpose() * 1.0/(n-1);
-        SVDDoublePrecisionType SVD(Cov.cast<double>(), Eigen::ComputeThinV);
-        VectorType singularValues = SVD.singularValues().cast<ScalarType>();
-        MatrixType V = SVD.matrixV().cast<ScalarType>();
+        typedef Eigen::JacobiSVD<MatrixType> SVDType;
+        typedef Eigen::JacobiSVD<MatrixTypeDoublePrecision> SVDDoublePrecisionType;
 
-        unsigned numComponentsAboveTolerance = ((singularValues.array() - noiseVariance - Superclass::TOLERANCE) > 0).count();
+        // We destinguish the case where we have more variables than samples and
+        // the case where we have more samples than variable.
+        // In the first case we compute the (smaller) inner product matrix instead of the full covariance matrix.
+        // It is known that this has the same non-zero singular values as the covariance matrix.
+        // Furthermore, it is possible to compute the corresponding eigenvectors of the covariance matrix from the
+        // decomposition.
 
-        // there can be at most n-1 nonzero singular values in this case. Everything else must be due to numerical inaccuracies
-        unsigned numComponentsToKeep = std::min(numComponentsAboveTolerance, n - 1);
-        // compute the pseudo inverse of the square root of the singular values
-        // which is then needed to recompute the PCA basis
-        VectorType singSqrt = singularValues.array().sqrt();
-        VectorType singSqrtInv = VectorType::Zero(singSqrt.rows());
-        for (unsigned i = 0; i < numComponentsToKeep; i++) {
-            assert(singSqrt(i) > Superclass::TOLERANCE);
-            singSqrtInv(i) = 1.0 / singSqrt(i);
+        if (n < p) {
+            // we compute the eigenvectors of the covariance matrix by computing an SVD of the
+            // n x n inner product matrix 1/(n-1) X0X0^T
+            MatrixType Cov = X0 * X0.transpose() * 1.0/(n-1);
+            SVDDoublePrecisionType SVD(Cov.cast<double>(), Eigen::ComputeThinV);
+            VectorType singularValues = SVD.singularValues().cast<ScalarType>();
+            MatrixType V = SVD.matrixV().cast<ScalarType>();
+
+            unsigned numComponentsAboveTolerance = ((singularValues.array() - noiseVariance - Superclass::TOLERANCE) > 0).count();
+
+            // there can be at most n-1 nonzero singular values in this case. Everything else must be due to numerical inaccuracies
+            unsigned numComponentsToKeep = std::min(numComponentsAboveTolerance, n - 1);
+            // compute the pseudo inverse of the square root of the singular values
+            // which is then needed to recompute the PCA basis
+            VectorType singSqrt = singularValues.array().sqrt();
+            VectorType singSqrtInv = VectorType::Zero(singSqrt.rows());
+            for (unsigned i = 0; i < numComponentsToKeep; i++) {
+                assert(singSqrt(i) > Superclass::TOLERANCE);
+                singSqrtInv(i) = 1.0 / singSqrt(i);
+            }
+
+            // we recover the eigenvectors U of the full covariance matrix from the eigenvectors V of the inner product matrix.
+            // We use the fact that if we decompose X as X=UDV^T, then we get X^TX = UD^2U^T and XX^T = VD^2V^T (exploiting the orthogonormality
+            // of the matrix U and V from the SVD). The additional factor sqrt(n-1) is to compensate for the 1/sqrt(n-1) in the formula
+            // for the covariance matrix.
+            MatrixType pcaBasis = (X0.transpose() * V * singSqrtInv.asDiagonal() / sqrt(n-1.0)).topLeftCorner(p, numComponentsToKeep);;
+
+            if (numComponentsToKeep == 0) {
+                throw StatisticalModelException("All the eigenvalues are below the given tolerance. Model cannot be built.");
+            }
+
+            VectorType sampleVarianceVector = singularValues.topRows(numComponentsToKeep);
+            VectorType pcaVariance = (sampleVarianceVector - VectorType::Ones(numComponentsToKeep) * noiseVariance);
+
+            StatisticalModelType* model = StatisticalModelType::Create(representer, mu, pcaBasis, pcaVariance, noiseVariance);
+
+            return model;
+        } else {
+            // we compute an SVD of the full p x p  covariance matrix 1/(n-1) X0^TX0 directly
+            SVDType SVD(X0.transpose() * X0 * 1.0/(n-1), Eigen::ComputeThinU);
+            VectorType singularValues = SVD.singularValues();
+            unsigned numComponentsToKeep = ((singularValues.array() - noiseVariance - Superclass::TOLERANCE) > 0).count();
+            MatrixType pcaBasis = SVD.matrixU().topLeftCorner(p, numComponentsToKeep);
+
+            if (numComponentsToKeep == 0) {
+                throw StatisticalModelException("All the eigenvalues are below the given tolerance. Model cannot be built.");
+            }
+
+            VectorType sampleVarianceVector = singularValues.topRows(numComponentsToKeep);
+            VectorType pcaVariance = (sampleVarianceVector - VectorType::Ones(numComponentsToKeep) * noiseVariance);
+            StatisticalModelType* model = StatisticalModelType::Create(representer, mu, pcaBasis, pcaVariance, noiseVariance);
+            return model;
         }
+        break;
 
-        // we recover the eigenvectors U of the full covariance matrix from the eigenvectors V of the inner product matrix.
-        // We use the fact that if we decompose X as X=UDV^T, then we get X^TX = UD^2U^T and XX^T = VD^2V^T (exploiting the orthogonormality
-        // of the matrix U and V from the SVD). The additional factor sqrt(n-1) is to compensate for the 1/sqrt(n-1) in the formula
-        // for the covariance matrix.
-        MatrixType pcaBasis = (X0.transpose() * V * singSqrtInv.asDiagonal() / sqrt(n-1.0)).topLeftCorner(p, numComponentsToKeep);;
+    case SelfAdjointEigenSolver:
+    {
+        // we compute the eigenvalues/eigenvectors of the full p x p  covariance matrix 1/(n-1) X0^TX0 directly
+
+        typedef Eigen::SelfAdjointEigenSolver<MatrixType> SelfAdjointEigenSolver;
+        SelfAdjointEigenSolver es;
+        es.compute(X0.transpose() * X0 * 1.0/(n-1));
+        VectorType eigenValues = es.eigenvalues().reverse(); // SelfAdjointEigenSolver orders the eigenvalues in increasing order
+
+
+        unsigned numComponentsToKeep = ((eigenValues.array() - noiseVariance - Superclass::TOLERANCE) > 0).count();
+        MatrixType pcaBasis = es.eigenvectors().rowwise().reverse().topLeftCorner(p, numComponentsToKeep);
 
         if (numComponentsToKeep == 0) {
             throw StatisticalModelException("All the eigenvalues are below the given tolerance. Model cannot be built.");
         }
 
-        VectorType sampleVarianceVector = singularValues.topRows(numComponentsToKeep);
-        VectorType pcaVariance = (sampleVarianceVector - VectorType::Ones(numComponentsToKeep) * noiseVariance);
-
-        StatisticalModelType* model = StatisticalModelType::Create(representer, mu, pcaBasis, pcaVariance, noiseVariance);
-
-        return model;
-    } else {
-        // we compute an SVD of the full p x p  covariance matrix 1/(n-1) X0^TX0 directly
-        SVDType SVD(X0.transpose() * X0 * 1.0/(n-1), Eigen::ComputeThinU);
-        VectorType singularValues = SVD.singularValues();
-        unsigned numComponentsToKeep = ((singularValues.array() - noiseVariance - Superclass::TOLERANCE) > 0).count();
-        MatrixType pcaBasis = SVD.matrixU().topLeftCorner(p, numComponentsToKeep);
-
-        if (numComponentsToKeep == 0) {
-            throw StatisticalModelException("All the eigenvalues are below the given tolerance. Model cannot be built.");
-        }
-
-        VectorType sampleVarianceVector = singularValues.topRows(numComponentsToKeep);
+        VectorType sampleVarianceVector = eigenValues.topRows(numComponentsToKeep);
         VectorType pcaVariance = (sampleVarianceVector - VectorType::Ones(numComponentsToKeep) * noiseVariance);
         StatisticalModelType* model = StatisticalModelType::Create(representer, mu, pcaBasis, pcaVariance, noiseVariance);
         return model;
+    }
+        break;
+
+    case RandomSVD:
+    {
+        throw StatisticalModelException("The RandomSVD is not jet supported in the PCAModelBuilder.");
+    }
+        break;
+    default:
+        throw StatisticalModelException("Unrecognized decomposition/eigenvalue solver method.");
+        return 0;
+        break;
     }
 }
 


### PR DESCRIPTION
Added support of SelfAdjointEigenSolver for the PCAModelBuilder

Motivation:
This solver is computationally way more efficient than the JacoviSVD if there are more samples than variables. However it is slighly less accurate.

Integration:
- There is a new enum in PCAModelBuilder which makes it possible to switch between the cases.
- By default, nothing has changed and the JacobiSVD is used.
- If the enum is provided when calling BuildNewModel on can now switch to the SelfAdjointEigenSolver of Eigen. It is only meaningfull to use this solver, if there are a lot of samples compared to the number of variables.
- I've tested it for the creation of a liver shape model. The accuracy loss is minor when visually compare the main components.

- I've added the RandomSVD to the enum as well and added a case in the switch statement in the PCAModelBuilder, but I haven't integrated it (currently an exception is thrown).