### PR TITLE
Statismo CLI tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if( WIN32 )
   set( Boost_USE_STATIC_LIBS ON )
 endif()
 
-find_package( Boost 1.50 COMPONENTS thread system date_time REQUIRED )
+find_package( Boost 1.50 COMPONENTS thread system date_time program_options  REQUIRED )
 include_directories( ${Boost_INCLUDE_DIRS} )
 
 link_directories( ${Boost_LIBRARY_DIRS} )
@@ -126,6 +126,8 @@ endif()
 option( BUILD_SHARED_LIBS "Build shared libraries" ON )
 
 option( BUILD_EXAMPLES "Build examples" ON )
+
+option( BUILD_CLI_TOOLS "Build command-line tools" ON )
 
 option( BUILD_WRAPPING "Build Python Wrappers (experimental)" OFF )
 mark_as_advanced(BUILD_WRAPPING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,19 @@ if( WIN32 )
   set( Boost_USE_STATIC_LIBS ON )
 endif()
 
-find_package( Boost 1.50 COMPONENTS thread system date_time program_options  REQUIRED )
+set( REQUIRED_BOOST_COMPONENTS thread system date_time )
+
+option( BUILD_CLI_TOOLS "Build command-line tools" ON )
+if( ${BUILD_CLI_TOOLS} MATCHES "ON" )
+	#search for pandoc to generate man pages for the cli tools
+	find_program( PANDOC NAMES pandoc )
+	mark_as_advanced( PANDOC )
+	
+	#the cli tools require the program_options component from boost
+	set( REQUIRED_BOOST_COMPONENTS ${REQUIRED_BOOST_COMPONENTS} program_options )
+endif()
+
+find_package( Boost 1.50 COMPONENTS ${REQUIRED_BOOST_COMPONENTS} REQUIRED )
 include_directories( ${Boost_INCLUDE_DIRS} )
 
 link_directories( ${Boost_LIBRARY_DIRS} )
@@ -127,7 +139,6 @@ option( BUILD_SHARED_LIBS "Build shared libraries" ON )
 
 option( BUILD_EXAMPLES "Build examples" ON )
 
-option( BUILD_CLI_TOOLS "Build command-line tools" ON )
 
 option( BUILD_WRAPPING "Build Python Wrappers (experimental)" OFF )
 mark_as_advanced(BUILD_WRAPPING)

--- a/modules/ITK/CMakeLists.txt
+++ b/modules/ITK/CMakeLists.txt
@@ -1,3 +1,12 @@
+if(MSVC11) #i.e. Visual Studio 2012
+  # Fix for VS2012 that has _VARIADIC_MAX set to 5. Don't set too high because it increases compiler memory usage / compile-time.
+  add_definitions( -D_VARIADIC_MAX=10 )
+  # Fix for another VS2012 problem: not all TR1 options are automatically detected, therefore we force them here.
+  add_definitions( -D BOOST_HAS_TR1 )
+  add_definitions( -D BOOST_NO_0X_HDR_INITIALIZER_LIST )
+endif()
+
+
 include_directories( BEFORE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${statismo_SOURCE_DIR}/modules/core/include

--- a/modules/ITK/CMakeLists.txt
+++ b/modules/ITK/CMakeLists.txt
@@ -11,6 +11,10 @@ if( ${BUILD_EXAMPLES} )
   add_subdirectory( examples )
 endif()
 
+if( ${BUILD_CLI_TOOLS} )
+  add_subdirectory( cli )
+endif()
+
 module_headertest( ITK )
 
 file( GLOB _ITK_hdrs

--- a/modules/ITK/cli/CMakeLists.txt
+++ b/modules/ITK/cli/CMakeLists.txt
@@ -1,0 +1,82 @@
+if(MSVC11) #i.e. Visual Studio 2012
+	# Fix for VS2012 that has _VARIADIC_MAX set to 10. Don't set too high because it increases compiler memory usage / compile-time.
+	add_definitions( -D_VARIADIC_MAX=10 )
+	# Fix for another VS2012 problem: not all TR1 options are automatically detected, therefore we force them here.
+	add_definitions( -D BOOST_HAS_TR1 )
+	add_definitions( -D BOOST_NO_0X_HDR_INITIALIZER_LIST )
+endif()
+
+#the idea here is to have an X.cxx and a X.md where X denotes the cli-command name.
+set( _cli_files
+	statismo-build-shape-model
+)
+
+#search for pandoc to generate man pages or chm help files
+find_program(PANDOC NAMES pandoc)
+mark_as_advanced(PANDOC)
+
+if(PANDOC)
+	message(STATUS "Pandoc found - generating documentation for the CLI tools")
+	#configuring manpage install dir
+	if(WIN32 AND NOT CYGWIN)
+		#put the manuals in the same directory as the binaries on windows
+		set(CLIDOC_INSTALL_DIR ${INSTALL_BIN_DIR})
+		set(CLIDOC_OUTPUT_DIR "${CMAKE_BINARY_DIR}/doc-cli" )
+	else()
+		#use cmake to find the man pages directory on *NIX
+		include(GNUInstallDirs)
+		if(CMAKE_INSTALL_MANDIR)
+			set(CLIDOC_INSTALL_DIR ${CMAKE_INSTALL_MANDIR})
+		else()
+            set(CLIDOC_INSTALL_DIR ${INSTALL_BIN_DIR})
+			message(STATUS "Couldn't find the man install directory - man pages will not be installed properly")
+		endif()
+		set(CLIDOC_OUTPUT_DIR "${CMAKE_BINARY_DIR}/man8" )
+	endif()
+	
+else()
+	message(STATUS "Pandoc not found - documentation will not be generated for the CLI tools")
+endif()
+
+#TODO will the man-pages be installed correctly on OS X?
+foreach( e ${_cli_files} )
+	add_executable( ${e} "${e}.cxx" )
+	target_link_libraries( ${e} statismo_core ${ITK_LIBRARIES} ${Boost_LIBRARIES})
+
+	install(TARGETS ${e} 
+		DESTINATION ${INSTALL_BIN_DIR}
+	)
+  
+	if(PANDOC AND CLIDOC_INSTALL_DIR)
+		message(STATUS "Creating documentation for ${e}")
+		
+		set(CLIDOC_MD_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/${e}.md)
+		if(WIN32 AND NOT CYGWIN)
+			set(CLIDOC_OUT_FILE ${CLIDOC_OUTPUT_DIR}/${e}.html)
+		else()
+			set(CLIDOC_OUT_FILE ${CLIDOC_OUTPUT_DIR}/${e}.8)
+		endif()
+		
+		add_custom_command(
+			OUTPUT ${CLIDOC_OUT_FILE}
+			COMMAND ${CMAKE_COMMAND} -E make_directory ${CLIDOC_OUTPUT_DIR}
+			# a '/' instead of a '\' in the inputfile path on windows leads to pandoc failing to automatically recoginze the file format -> we have specify it manually
+			COMMAND ${PANDOC} -f markdown -s ${CLIDOC_MD_SOURCE} -o ${CLIDOC_OUT_FILE}
+			MAIN_DEPENDENCY ${CLIDOC_MD_SOURCE}
+		)
+		
+		#build the cli documentation by default
+		add_custom_target(doc-cli ALL
+			DEPENDS ${CLIDOC_OUT_FILE}
+			SOURCES ${CLIDOC_MD_SOURCE}
+		)
+
+		#install the entire cli documentation directory
+		install(DIRECTORY ${CLIDOC_OUTPUT_DIR}
+			DESTINATION ${CLIDOC_INSTALL_DIR}
+		)
+
+
+	endif()
+endforeach()
+

--- a/modules/ITK/cli/CMakeLists.txt
+++ b/modules/ITK/cli/CMakeLists.txt
@@ -1,25 +1,16 @@
-if(MSVC11) #i.e. Visual Studio 2012
-	# Fix for VS2012 that has _VARIADIC_MAX set to 10. Don't set too high because it increases compiler memory usage / compile-time.
-	add_definitions( -D_VARIADIC_MAX=10 )
-	# Fix for another VS2012 problem: not all TR1 options are automatically detected, therefore we force them here.
-	add_definitions( -D BOOST_HAS_TR1 )
-	add_definitions( -D BOOST_NO_0X_HDR_INITIALIZER_LIST )
-endif()
-
 #the idea here is to have an X.cxx and a X.md where X denotes the cli-command name.
 set( _cli_files
 	statismo-build-shape-model
+	statismo-build-deformation-model
+	statismo-build-gp-model
+	statismo-sample
 )
 
-#search for pandoc to generate man pages or chm help files
-find_program(PANDOC NAMES pandoc)
-mark_as_advanced(PANDOC)
-
 if(PANDOC)
-	message(STATUS "Pandoc found - generating documentation for the CLI tools")
-	#configuring manpage install dir
+	message(STATUS "Found pandoc - generating documentation for the CLI tools")
+	#configuring man page install dir
 	if(WIN32 AND NOT CYGWIN)
-		#put the manuals in the same directory as the binaries on windows
+		#put the directory with the manuals in the same directory as the binaries on windows
 		set(CLIDOC_INSTALL_DIR ${INSTALL_BIN_DIR})
 		set(CLIDOC_OUTPUT_DIR "${CMAKE_BINARY_DIR}/doc-cli" )
 	else()
@@ -29,7 +20,7 @@ if(PANDOC)
 			set(CLIDOC_INSTALL_DIR ${CMAKE_INSTALL_MANDIR})
 		else()
             set(CLIDOC_INSTALL_DIR ${INSTALL_BIN_DIR})
-			message(STATUS "Couldn't find the man install directory - man pages will not be installed properly")
+			message(STATUS "Couldn't find the man install directory - man pages will NOT be installed properly")
 		endif()
 		set(CLIDOC_OUTPUT_DIR "${CMAKE_BINARY_DIR}/man8" )
 	endif()
@@ -38,45 +29,44 @@ else()
 	message(STATUS "Pandoc not found - documentation will not be generated for the CLI tools")
 endif()
 
-#TODO will the man-pages be installed correctly on OS X?
 foreach( e ${_cli_files} )
-	add_executable( ${e} "${e}.cxx" )
-	target_link_libraries( ${e} statismo_core ${ITK_LIBRARIES} ${Boost_LIBRARIES})
+		add_executable( ${e} "${e}.cxx" )
+		target_link_libraries( ${e} statismo_core ${ITK_LIBRARIES} ${Boost_LIBRARIES})
+		install(TARGETS ${e}
+			DESTINATION ${INSTALL_BIN_DIR}
+		)
+endforeach()
 
-	install(TARGETS ${e} 
-		DESTINATION ${INSTALL_BIN_DIR}
-	)
-  
-	if(PANDOC AND CLIDOC_INSTALL_DIR)
-		message(STATUS "Creating documentation for ${e}")
-		
+unset(CLIDOC_TARGET_DEPENDENCIES)
+unset(CLIDOC_TARGET_SOURCES)
+if(PANDOC AND CLIDOC_INSTALL_DIR)
+	foreach( e ${_cli_files} )
 		set(CLIDOC_MD_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/${e}.md)
 		if(WIN32 AND NOT CYGWIN)
 			set(CLIDOC_OUT_FILE ${CLIDOC_OUTPUT_DIR}/${e}.html)
 		else()
 			set(CLIDOC_OUT_FILE ${CLIDOC_OUTPUT_DIR}/${e}.8)
 		endif()
-		
+
 		add_custom_command(
 			OUTPUT ${CLIDOC_OUT_FILE}
 			COMMAND ${CMAKE_COMMAND} -E make_directory ${CLIDOC_OUTPUT_DIR}
-			# a '/' instead of a '\' in the inputfile path on windows leads to pandoc failing to automatically recoginze the file format -> we have specify it manually
+			# a '/' instead of a '\' in the input-file's path on windows leads to pandoc failing to automatically recoginze the file format -> we have specify it manually
 			COMMAND ${PANDOC} -f markdown -s ${CLIDOC_MD_SOURCE} -o ${CLIDOC_OUT_FILE}
 			MAIN_DEPENDENCY ${CLIDOC_MD_SOURCE}
 		)
 		
-		#build the cli documentation by default
-		add_custom_target(doc-cli ALL
-			DEPENDS ${CLIDOC_OUT_FILE}
-			SOURCES ${CLIDOC_MD_SOURCE}
-		)
+		list(APPEND CLIDOC_TARGET_DEPENDENCIES ${CLIDOC_OUT_FILE} )
+		list(APPEND CLIDOC_TARGET_SOURCES ${CLIDOC_MD_SOURCE} )
+	endforeach()
 
-		#install the entire cli documentation directory
-		install(DIRECTORY ${CLIDOC_OUTPUT_DIR}
-			DESTINATION ${CLIDOC_INSTALL_DIR}
-		)
-
-
-	endif()
-endforeach()
-
+	#build the cli documentation by default
+	add_custom_target(doc-cli ALL
+		DEPENDS ${CLIDOC_TARGET_DEPENDENCIES}
+		SOURCES ${CLIDOC_TARGET_SOURCES}
+	)
+	#install the entire cli documentation directory
+	install(DIRECTORY ${CLIDOC_OUTPUT_DIR}
+		DESTINATION ${CLIDOC_INSTALL_DIR}
+	)
+endif()

--- a/modules/ITK/cli/statismo-build-deformation-model.cxx
+++ b/modules/ITK/cli/statismo-build-deformation-model.cxx
@@ -1,0 +1,142 @@
+#include <itkDirectory.h>
+#include <itkImageFileReader.h>
+
+#include "itkDataManager.h"
+#include "itkPCAModelBuilder.h"
+#include "itkStandardImageRepresenter.h"
+#include "itkStatisticalModel.h"
+
+#include <boost/program_options.hpp>
+
+#include "statismo-build-models-utils.h"
+
+namespace po = boost::program_options;
+
+
+struct programOptions {
+    bool bDisplayHelp;
+    string strDataListFile;
+    string strOutputFileName;
+    float fNoiseVariance;
+    bool bAutoNoise;
+};
+
+po::options_description initializeProgramOptions(programOptions& poParameters);
+bool isOptionsConflictPresent(programOptions& opt);
+void buildAndSaveDeformationModel(programOptions opt);
+
+
+
+int main(int argc, char** argv) {
+    programOptions poParameters;
+
+    po::positional_options_description optPositional;
+    optPositional.add("output-file", 1);
+    po::options_description optAllOptions = initializeProgramOptions(poParameters);
+
+
+    po::variables_map vm;
+    try {
+        po::parsed_options parsedOptions = po::command_line_parser(argc, argv).options(optAllOptions).positional(optPositional).run();
+        po::store(parsedOptions, vm);
+        po::notify(vm);
+    } catch (po::error& e) {
+        cerr << "An exception occurred while parsing the Command line:"<<endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (poParameters.bDisplayHelp == true) {
+        cout << optAllOptions << endl;
+        return EXIT_SUCCESS;
+    }
+    if (isOptionsConflictPresent(poParameters) == true)	{
+        cerr << "A conflict in the options exists or insufficient options were set." << endl;
+        cout << optAllOptions << endl;
+        return EXIT_FAILURE;
+    }
+
+    try {
+        buildAndSaveDeformationModel(poParameters);
+    } catch (ifstream::failure & e) {
+        cerr << "Could not read the data-list:" << endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    } catch (itk::ExceptionObject & e) {
+        cerr << "Could not build the model:" << endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+bool isOptionsConflictPresent(programOptions& opt) {
+    if (opt.strDataListFile == "" || opt.strOutputFileName == "" ) {
+        return true;
+    }
+
+    if (opt.strDataListFile == opt.strOutputFileName) {
+        return false;
+    }
+
+    return false;
+}
+
+void buildAndSaveDeformationModel(programOptions opt) {
+    const unsigned Dimensions = 3;
+    typedef itk::Image< itk::Vector<float, Dimensions>, Dimensions > ImageType;
+    typedef itk::StandardImageRepresenter<itk::Vector<float, 3>, 3> RepresenterType;
+    typedef itk::PCAModelBuilder<ImageType> ModelBuilderType;
+    typedef itk::StatisticalModel<ImageType> StatisticalModelType;
+    typedef std::vector<std::string> StringVectorType;
+    typedef itk::DataManager<ImageType> DataManagerType;
+    typedef itk::ImageFileReader<ImageType> ImageReaderType;
+    typedef list<pair<ImageType::Pointer, string> > ImageList;
+
+    RepresenterType::Pointer representer = RepresenterType::New();
+    DataManagerType::Pointer dataManager = DataManagerType::New();
+
+    ImageList images;
+    StringList filenames = getFileList(opt.strDataListFile);
+    for (StringList::const_iterator it = filenames.begin(); it != filenames.end(); it++) {
+        ImageReaderType::Pointer reader = ImageReaderType::New();
+        reader->SetFileName(it->c_str());
+        reader->Update();
+        images.push_back(make_pair(reader->GetOutput(), *it));
+    }
+
+    if (images.size() == 0) {
+        itk::ExceptionObject e(__FILE__, __LINE__, "No Data was loaded and thus the model can't be built.", ITK_LOCATION);
+        throw e;
+    }
+    representer->SetReference(images.begin()->first.GetPointer());
+    dataManager->SetRepresenter(representer);
+
+    for (ImageList::const_iterator it = images.begin(); it != images.end(); it++) {
+        dataManager->AddDataset(it->first, it->second.c_str());
+    }
+
+    StatisticalModelType::Pointer model;
+    ModelBuilderType::Pointer pcaModelBuilder = ModelBuilderType::New();
+    model = pcaModelBuilder->BuildNewModel(dataManager->GetData(), opt.fNoiseVariance);
+    model->Save(opt.strOutputFileName.c_str());
+}
+
+po::options_description initializeProgramOptions(programOptions& poParameters) {
+    po::options_description optMandatory("Mandatory options");
+    optMandatory.add_options()
+    ("data-list,d", po::value<string>(&poParameters.strDataListFile), "File containing a list of meshes to build the deformation model from")
+    ("output-file,o", po::value<string>(&poParameters.strOutputFileName), "Name of the output file")
+    ;
+    po::options_description optAdditional("Optional options");
+    optAdditional.add_options()
+    ("noise,n", po::value<float>(&poParameters.fNoiseVariance)->default_value(0), "Noise variance of the PPCA model")
+//		("auto-noise,a", po::bool_switch(&poParameters.bAutoNoise), "Estimate noise directly from dropped components") //currently not available
+    ("help,h", po::bool_switch(&poParameters.bDisplayHelp), "Display this help message")
+    ;
+
+    po::options_description optAllOptions;
+    optAllOptions.add(optMandatory).add(optAdditional);
+    return optAllOptions;
+}

--- a/modules/ITK/cli/statismo-build-deformation-model.md
+++ b/modules/ITK/cli/statismo-build-deformation-model.md
@@ -1,0 +1,48 @@
+% STATISMO-BUILD-DEFORMATION-MODEL(8)
+
+
+# NAME
+
+statismo-build-deformation-model - builds deformation models from a list of deformation fields
+
+# SYNOPSIS
+
+statismo-buid-deformation-model [*options*] *output-file*
+
+# DESCRIPTION
+
+statismo-build-deformation-model is used to build a deformation model from a given list of deformation fields. 
+**All the deformation fields need to have the same domain (i.e. origin, spacing and size needs to be the same)**
+
+
+# OPTIONS
+-d, \--data-list *DATA_LIST*
+:	*DATA_LIST* is the path to a file containing a list of files storing deformation fields that will be used to create the deformation model. Please only give the path to **one** file per line in the data-list-file.
+
+-o, \--output-file *OUTPUT_FILE*
+:	*OUTPUT_FILE* is the path where the newly build model should be saved.
+
+-n, \--noise *NOISE*
+:	Specify the noise variance of the PPCA model. Defaults to 0
+
+<!-- 
+-a, \--auto-noise 
+:	Estimate noise directly from dropped components.
+-->
+
+
+# Examples 
+Build a deformation model from the deformation fields specified in the file data.txt
+
+    statismo-build-deformation-model -d data.txt shapemodel.h5
+
+# SEE ALSO
+
+*statismo-build-shape-model* (8).
+Builds shape models from a list of meshes.
+
+*statismo-build-gp-model* (8).
+Builds shape or deformation models from a given gaussian process definition.
+
+*statismo-sample* (8).
+Draws samples from a model.

--- a/modules/ITK/cli/statismo-build-gp-model-kernels.h
+++ b/modules/ITK/cli/statismo-build-gp-model-kernels.h
@@ -1,0 +1,89 @@
+#include <string>
+#include <vector>
+#include <map>
+
+#include <itkImage.h>
+#include <itkMesh.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include "Kernels.h"
+#include "KernelCombinators.h"
+
+using namespace std;
+
+/*
+You can add your kernels here:
+	1. Either #include your kernel or put the class in here
+	2. Write a function in this file that creates your kernel (create it on the heap and NOT on the stack; it will be deleted, don't worry)
+	   Your function will receive a vector containing the kernel arguments (vector<string>). You have to parse them or thrown an itk::ExceptionObject if something goes wrong.
+	3. Add your kernel to the kernel map (do this in the function createKernelMap(); your kernel name has to be lowercase)
+	4. Document your kernel in the statismo-build-gp-model.md file. (Examples for kernels with multiple parameters are in there, but currently commented out)
+*/
+
+
+const unsigned Dimensions = 3;
+typedef itk::Mesh<float, Dimensions> DataTypeShape;
+typedef itk::Image< itk::Vector<float, Dimensions>, Dimensions > DataTypeDeformation;
+struct KernelContainer {
+    const statismo::ScalarValuedKernel<DataTypeShape::PointType>* (*createKernelShape)(vector<string> kernelArgs);
+    const statismo::ScalarValuedKernel<DataTypeDeformation::PointType>* (*createKernelDeformation)(vector<string> kernelArgs);
+};
+typedef map<string, KernelContainer> KernelMapType;
+KernelMapType kernelMap;
+
+
+template <class TPoint>
+class GaussianKernel : public statismo::ScalarValuedKernel<TPoint> {
+  public:
+    typedef typename  TPoint::CoordRepType CoordRepType;
+    typedef vnl_vector<CoordRepType> VectorType;
+
+    GaussianKernel(double sigma) : m_sigma(sigma), m_sigma2(sigma * sigma) {}
+
+    inline double operator()(const TPoint& x, const TPoint& y) const {
+        VectorType xv = x.GetVnlVector();
+        VectorType yv = y.GetVnlVector();
+
+        VectorType r = yv - xv;
+        return exp(-dot_product(r, r) / m_sigma2);
+    }
+
+    std::string GetKernelInfo() const {
+        std::ostringstream os;
+        os << "GaussianKernel(" << m_sigma << ")";
+        return os.str();
+    }
+
+  private:
+
+    double m_sigma;
+    double m_sigma2;
+};
+
+
+template <class TPoint>
+const statismo::ScalarValuedKernel<TPoint>* createGaussianKernel(vector<string> kernelArgs) {
+    if (kernelArgs.size() == 1) {
+        try {
+            double sigma = boost::lexical_cast<double>(kernelArgs[0]);
+            if (sigma <= 0) {
+                itk::ExceptionObject e(__FILE__, __LINE__, "Error: sigma has to be > 0", ITK_LOCATION);
+                throw e;
+            }
+            //The kernel will be deleted automatically once it's no longer being used
+            return new GaussianKernel<TPoint>(sigma);
+        } catch (boost::bad_lexical_cast &) {
+            itk::ExceptionObject e(__FILE__, __LINE__, "Error: could not parse the kernel argument (expected a floating point number)", ITK_LOCATION);
+            throw e;
+        }
+    } else {
+        itk::ExceptionObject e(__FILE__, __LINE__, "The Gaussian Kernel takes one and only one argument: sigma. You provided " + boost::lexical_cast<string>(kernelArgs.size()) + " Arguments.", ITK_LOCATION);
+        throw e;
+    }
+}
+
+#define addKernelToKernelMap(kernelName, functionName){KernelContainer kernel;kernel.createKernelDeformation = &functionName < DataTypeDeformation::PointType >;kernel.createKernelShape = &functionName < DataTypeShape::PointType >;kernelMap.insert(make_pair(boost::algorithm::to_lower_copy(string(kernelName)), kernel)); }
+void createKernelMap() {
+    addKernelToKernelMap("gauss", createGaussianKernel)
+}

--- a/modules/ITK/cli/statismo-build-gp-model.cxx
+++ b/modules/ITK/cli/statismo-build-gp-model.cxx
@@ -1,0 +1,194 @@
+#include <iostream>
+
+#include <itkDirectory.h>
+#include <itkMeshFileReader.h>
+#include <itkImageFileReader.h>
+
+#include "itkDataManager.h"
+#include "itkLowRankGPModelBuilder.h"
+#include "itkStandardImageRepresenter.h"
+#include "itkStandardMeshRepresenter.h"
+#include "itkStatisticalModel.h"
+
+#include <boost/program_options.hpp>
+
+//Add new kernels in this file (and document their usage in the statismo-build-gp-model.md file)
+#include "statismo-build-gp-model-kernels.h"
+
+namespace po = boost::program_options;
+
+struct programOptions {
+    bool bDisplayHelp;
+    string strReferenceFile;
+    string strKernel;
+    string strType;
+    vector<string> vKernelParameters;
+    float fKernelScale;
+    int iNrOfBasisFunctions;
+    string strOutputFileName;
+};
+
+po::options_description initializeProgramOptions(programOptions& poParameters);
+bool isOptionsConflictPresent(programOptions& opt);
+template <class DataType, class RepresenterType, class DataReaderType, bool isShapeModel>
+void buildAndSaveModel(programOptions opt);
+void createKernelMap();
+string getAvailableKernelsStr();
+
+
+int main(int argc, char** argv) {
+    createKernelMap();
+
+    programOptions poParameters;
+
+    po::positional_options_description optPositional;
+    optPositional.add("output-file", 1);
+    po::options_description optAllOptions = initializeProgramOptions(poParameters);
+
+
+    po::variables_map vm;
+    try {
+        po::parsed_options parsedOptions = po::command_line_parser(argc, argv).options(optAllOptions).positional(optPositional).run();
+        po::store(parsedOptions, vm);
+        po::notify(vm);
+    } catch (po::error& e) {
+        cerr << "An exception occurred while parsing the Command line:"<<endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (poParameters.bDisplayHelp == true) {
+        cout << optAllOptions << endl;
+        return EXIT_SUCCESS;
+    }
+    if (isOptionsConflictPresent(poParameters) == true)	{
+        cerr << "A conflict in the options exists or insufficient options were set." << endl;
+        cout << optAllOptions << endl;
+        return EXIT_FAILURE;
+    }
+
+    try {
+        if (poParameters.strType == "shape") {
+            typedef itk::StandardMeshRepresenter<float, Dimensions> RepresenterType;
+            typedef itk::MeshFileReader<DataTypeShape> DataReaderType;
+            buildAndSaveModel<DataTypeShape, RepresenterType, DataReaderType, true>(poParameters);
+        } else {
+            typedef itk::StandardImageRepresenter<itk::Vector<float, Dimensions>, Dimensions> RepresenterType;
+            typedef itk::ImageFileReader<DataTypeDeformation> DataReaderType;
+            buildAndSaveModel<DataTypeDeformation, RepresenterType, DataReaderType, false>(poParameters);
+        }
+
+    } catch (itk::ExceptionObject & e) {
+        cerr << "Could not build the model:" << endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+bool isOptionsConflictPresent(programOptions& opt) {
+    boost::algorithm::to_lower(opt.strKernel);
+    boost::algorithm::to_lower(opt.strType);
+
+    if (opt.strType != "shape" && opt.strType != "deformation") {
+        return true;
+    }
+
+    if (opt.strOutputFileName == "" || opt.strReferenceFile == "") {
+        return true;
+    }
+
+    if (opt.strOutputFileName == opt.strReferenceFile) {
+        return true;
+    }
+
+    if (opt.iNrOfBasisFunctions < 1) {
+        return true;
+    }
+
+    return false;
+}
+
+template <class DataType, class RepresenterType, class DataReaderType, bool isShapeModel>
+void buildAndSaveModel(programOptions opt) {
+    typedef itk::LowRankGPModelBuilder<DataType> ModelBuilderType;
+    typedef itk::StatisticalModel<DataType> StatisticalModelType;
+    typedef typename DataType::PointType PointType;
+
+    typename DataReaderType::Pointer refReader = DataReaderType::New();
+    refReader->SetFileName(opt.strReferenceFile);
+    refReader->Update();
+
+    typename RepresenterType::Pointer representer = RepresenterType::New();
+    representer->SetReference(refReader->GetOutput());
+
+    KernelMapType::const_iterator it = kernelMap.find(opt.strKernel);
+    if (it == kernelMap.end()) {
+        itk::ExceptionObject e(__FILE__, __LINE__, "The kernel '" + opt.strKernel + "' isn't available. Available kernels: " + getAvailableKernelsStr() , ITK_LOCATION);
+        throw e;
+    }
+
+
+    typedef boost::scoped_ptr<const statismo::ScalarValuedKernel<PointType> > MatrixPointerType;
+    MatrixPointerType pKernel;
+    if (isShapeModel == true) {
+        pKernel.reset((statismo::ScalarValuedKernel<PointType>*) it->second.createKernelShape(opt.vKernelParameters));
+    } else {
+        pKernel.reset((statismo::ScalarValuedKernel<PointType>*) it->second.createKernelDeformation(opt.vKernelParameters));
+    }
+
+    const statismo::MatrixValuedKernel<PointType>& mvGk = statismo::UncorrelatedMatrixValuedKernel<PointType>(pKernel.get(), Dimensions);
+    const statismo::MatrixValuedKernel<PointType>& scaledGk = statismo::ScaledKernel<PointType>(&mvGk, opt.fKernelScale);
+
+    typename ModelBuilderType::Pointer gpModelBuilder = ModelBuilderType::New();
+    gpModelBuilder->SetRepresenter(representer);
+
+    typename StatisticalModelType::Pointer model;
+    if (isShapeModel == true) {
+        model = gpModelBuilder->BuildNewModel(refReader->GetOutput(), scaledGk, opt.iNrOfBasisFunctions);
+    } else {
+        model = gpModelBuilder->BuildNewZeroMeanModel(scaledGk, opt.iNrOfBasisFunctions);
+    }
+
+    model->Save(opt.strOutputFileName.c_str());
+}
+
+string getAvailableKernelsStr() {
+    string ret;
+    KernelMapType::size_type mapEnd = kernelMap.size();
+    KernelMapType::size_type i = 0;
+    for (KernelMapType::const_iterator it = kernelMap.begin(); it != kernelMap.end(); it++, i++) {
+        if (i + 1 == mapEnd && mapEnd > 1) {
+            ret += " and ";
+        } else if (i > 0) {
+            ret += ", ";
+        }
+        ret += it->first;
+    }
+    return ret;
+}
+
+
+po::options_description initializeProgramOptions(programOptions& poParameters) {
+    string kernelHelp = "Specifies the kernel (covariance function). The following kernels are available: "+getAvailableKernelsStr();
+
+    po::options_description optMandatory("Mandatory options");
+    optMandatory.add_options()
+    ("type,t", po::value<string>(&poParameters.strType)->default_value("shape"), "Specifies the type of the model: shape and deformation are the two available types")
+    ("kernel,k", po::value<string>(&poParameters.strKernel), kernelHelp.c_str())
+    ("parameters,p", po::value<vector<string> >(&poParameters.vKernelParameters)->multitoken(), "Specifies the kernel parameters. The Parameters depend on the kernel")
+    ("scale,s", po::value<float>(&poParameters.fKernelScale)->default_value(1), "A Scaling factor with which the Kernel will be scaled")
+    ("numberofbasisfunctions,n", po::value<int>(&poParameters.iNrOfBasisFunctions)->default_value(25), "Number of basis functions/parameters the model will have")
+    ("reference,r", po::value<string>(&poParameters.strReferenceFile), "The reference that will be used to build the model")
+    ("output-file,o", po::value<string>(&poParameters.strOutputFileName), "Name of the output file where the model will be saved")
+    ;
+    po::options_description optAdditional("Optional options");
+    optAdditional.add_options()
+    ("help,h", po::bool_switch(&poParameters.bDisplayHelp), "Display this help message")
+    ;
+
+    po::options_description optAllOptions;
+    optAllOptions.add(optMandatory).add(optAdditional);
+    return optAllOptions;
+}

--- a/modules/ITK/cli/statismo-build-gp-model.md
+++ b/modules/ITK/cli/statismo-build-gp-model.md
@@ -1,0 +1,74 @@
+% STATISMO-BUILD-GP-MODEL(8)
+
+# NAME
+
+statismo-build-gp-model - builds shape or deformation models from a given gaussian process definition
+
+# SYNOPSIS
+
+statismo-buid-gp-model [*options*] -r *reference-file* *output-file*
+
+# DESCRIPTION
+
+statismo-build-gp-model is used to build a shape or deformation model from a gaussian process definition.
+
+# OPTIONS
+-t, \--type *TYPE*
+:	Specify the type of the model. *TYPE* can either be **shape** or **deformation**.
+
+-k, \--kernel *KERNEL* 
+:	Specify the kernel (covariance function) of the gaussian process.
+   Supported kernels: **gauss**
+
+-p, \--parameters *KERNEL_PARAMETERS*
+:	*KERNEL_PARAMETERS* are the kernel parameters. The exact parameters depend on the kernel:
+
+	- gauss: The gaussian kernel has one parameter
+		- sigma: This parameter is a float that sets the sigma parameter in the gaussian kernel. Bigger values make the changes "smoother".
+
+<!-- 
+	- kernel with 2 parameters: this is an example for man writing purposes and is commented out
+		- param1: float of some sort
+		- param2 boolean of some sort
+-->
+	
+-s, \--scale *SCALE* 
+:	*SCALE* is a scaling factor the kernel is scaled with. The bigger this value is, the stronger the change is when modifying a model parameter.
+
+-n, \--numberofbasisfunctions *NUMBER_OF_BASIS_FUNCTIONS* 
+:	*NUMBER_OF_BASIS_FUNCTIONS*  specifies how many parameters the model will have.
+
+-r, \--reference *REFERENCE_FILE*
+:	*REFERENCE_FILE* is the path to the reference file (a mesh or an image) that will be used to construct the model.
+
+-o, \--output-file *OUTPUT_FILE*
+:	*OUTPUT_FILE* is the path where the model will be saved.
+
+# Examples 
+
+Build a shape model with a gaussian kernel and 50 basis functions:
+
+    statismo-build-gp-model -t shape -k gauss -p 95.5 -s 42.42 -n 50 -r reference-mesh.vtk model.h5
+
+Build a deformation model with a gaussian kernel and 25 basis functions:
+
+    statismo-build-gp-model -t deformation -k gauss -p 100 -s 10 -n 25 -r reference-image.vtk model.h5
+
+<!-- 
+Build a shape model with a multi-parameter kernel and 50 basis functions: (this is an example on how to use multiple kernel parameters for future documentation writers)
+
+    statismo-build-gp-model -t shape -k multi-parameter[float,bool,int] -p 5.12 true -99 -s 100 -n 50 -r reference-mesh.vtk model.h5
+	
+--> 
+
+# SEE ALSO
+
+
+*statismo-build-shape-model* (8).
+Builds shape models from a list of meshes.
+
+*statismo-build-deformation-model* (8).
+Builds deformation models from a list of deformation fields
+
+*statismo-sample* (8).
+Draws samples from a model.

--- a/modules/ITK/cli/statismo-build-models-utils.h
+++ b/modules/ITK/cli/statismo-build-models-utils.h
@@ -1,0 +1,175 @@
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+#include <iostream>
+
+using namespace std;
+
+typedef list<string> StringList;
+StringList getFileList(std::string path);
+
+template<class MeshType>
+typename MeshType::Pointer calculateMeanMesh(vector<typename MeshType::Pointer> meshes);
+
+template<class MeshType>
+float calculateMeshDistance(typename MeshType::Pointer mesh1, typename MeshType::Pointer mesh2);
+
+template<class MeshType, class LandmarkBasedTransformInitializerType, class TransformType, class FilterType>
+vector<typename MeshType::Pointer> superimposeMeshes(vector<typename MeshType::Pointer> originalMeshes, typename MeshType::Pointer referenceMesh, std::set<unsigned> landmarkIndices);
+
+template<class MeshType, class LandmarkBasedTransformInitializerType, class TransformType, class FilterType>
+typename MeshType::Pointer calculateProcrustesMeanMesh(vector<typename MeshType::Pointer> meshes, unsigned maxIterations, unsigned nrOfLandmarks, float breakIfChangeBelow);
+
+
+
+template<class MeshType, class LandmarkBasedTransformInitializerType, class TransformType, class FilterType>
+typename MeshType::Pointer calculateProcrustesMeanMesh(vector<typename MeshType::Pointer> meshes, unsigned maxIterations, unsigned nrOfLandmarks, float breakIfChangeBelow) {
+    //the initial mesh to which all others will be aligned to is the first one in the list here. Any other mesh could be chosen as well
+    typename MeshType::Pointer referenceMesh = *meshes.begin();
+
+    unsigned rngSeed = time(0);
+    unsigned meshVerticesCount = referenceMesh->GetNumberOfPoints();
+    srand(rngSeed);
+    std::set<unsigned> pointNumbers;
+    while (pointNumbers.size() < min(nrOfLandmarks, meshVerticesCount)) {
+        unsigned randomIndex = ((unsigned) rand()) % meshVerticesCount;
+        pointNumbers.insert(randomIndex);
+    }
+
+    float fPreviousDifference = -1;
+
+    for (unsigned i = 0; i < maxIterations; i++) {
+        //calculate the difference to the previous iteration's mesh and break if the difference is very small
+        vector<typename MeshType::Pointer> translatedMeshes = superimposeMeshes<MeshType, LandmarkBasedTransformInitializerType, TransformType, FilterType>(meshes, referenceMesh, pointNumbers);
+        typename MeshType::Pointer meanMesh = calculateMeanMesh<MeshType>(translatedMeshes);
+        float fDifference = calculateMeshDistance<MeshType>(meanMesh, referenceMesh);
+        float fDifferenceDelta = abs(fDifference - fPreviousDifference);
+        fPreviousDifference = fDifference;
+        referenceMesh = meanMesh;
+
+        if (fDifferenceDelta < breakIfChangeBelow) {
+            break;
+        }
+    }
+    return referenceMesh;
+}
+
+template<class MeshType, class LandmarkBasedTransformInitializerType, class TransformType, class FilterType>
+vector<typename MeshType::Pointer> superimposeMeshes(vector<typename MeshType::Pointer> originalMeshes, typename MeshType::Pointer referenceMesh, std::set<unsigned> landmarkIndices) {
+    vector<typename MeshType::Pointer> translatedMeshes(originalMeshes.begin(), originalMeshes.end());
+    for (typename vector<typename MeshType::Pointer>::iterator it = translatedMeshes.begin(); it != translatedMeshes.end(); it++) {
+        typedef typename LandmarkBasedTransformInitializerType::LandmarkPointContainer LandmarkContainerType;
+        LandmarkContainerType movingLandmarks;
+        LandmarkContainerType fixedLandmarks;
+        typename MeshType::Pointer movingMesh = *it;
+
+        //Only use a subset of the meshes' points for the alignment since we don't have that many degrees of freedom anyways and since calculating a SVD with too many points is expensive
+        for (std::set<unsigned>::const_iterator rng = landmarkIndices.begin(); rng != landmarkIndices.end(); rng++) {
+            movingLandmarks.push_back(movingMesh->GetPoint(*rng));
+            fixedLandmarks.push_back(referenceMesh->GetPoint(*rng));
+        }
+
+        //only rotate & translate the moving mesh to best fit with the fixed mesh; there's no scaling taking place.
+        typename LandmarkBasedTransformInitializerType::Pointer landmarkBasedTransformInitializer = LandmarkBasedTransformInitializerType::New();
+        landmarkBasedTransformInitializer->SetFixedLandmarks(fixedLandmarks);
+        landmarkBasedTransformInitializer->SetMovingLandmarks(movingLandmarks);
+        typename TransformType::Pointer transform = TransformType::New();
+        transform->SetIdentity();
+        landmarkBasedTransformInitializer->SetTransform(transform);
+        landmarkBasedTransformInitializer->InitializeTransform();
+
+        typename FilterType::Pointer filter = FilterType::New();
+        filter->SetInput(movingMesh);
+        filter->SetTransform(transform);
+        filter->Update();
+
+        *it = filter->GetOutput();
+    }
+    return translatedMeshes;
+}
+
+
+template<class MeshType>
+float calculateMeshDistance(typename MeshType::Pointer mesh1, typename MeshType::Pointer mesh2) {
+    if (mesh1->GetNumberOfPoints() != mesh2->GetNumberOfPoints() || mesh1->GetNumberOfCells() != mesh2->GetNumberOfCells()) {
+        itk::ExceptionObject e(__FILE__, __LINE__, "Both meshes must have the same number of Edges & Vertices", ITK_LOCATION);
+        throw e;
+    }
+
+    float fDifference = 0;
+    for (unsigned j = 0; j < mesh1->GetNumberOfPoints(); j++) {
+        typename MeshType::PointType point1 = mesh1->GetPoint(j);
+        typename MeshType::PointType point2 = mesh2->GetPoint(j);
+        for (unsigned k = 0; k < mesh1->GetPoint(j).Size(); k++) {
+            fDifference += (point1[k] - point2[k])*(point1[k] - point2[k]);
+        }
+    }
+    fDifference /= (mesh1->GetNumberOfPoints() + MeshType::PointDimension);
+    return fDifference;
+}
+
+template<class MeshType>
+typename MeshType::Pointer calculateMeanMesh(vector<typename MeshType::Pointer> meshes) {
+    if (meshes.size() == 0) {
+        itk::ExceptionObject e(__FILE__, __LINE__, "Can't calculate the mean since no meshes were provided.", ITK_LOCATION);
+        throw e;
+    }
+
+    typename MeshType::Pointer meanMesh;
+    for (typename vector<typename MeshType::Pointer>::const_iterator i = meshes.begin(); i != meshes.end(); i++) {
+        typename MeshType::Pointer mesh = *i;
+        if (!meanMesh) {
+            meanMesh = mesh;
+        } else {
+            if (meanMesh->GetNumberOfPoints() != mesh->GetNumberOfPoints() || meanMesh->GetNumberOfCells() != mesh->GetNumberOfCells()) {
+                itk::ExceptionObject e(__FILE__, __LINE__, "All meshes must have the same number of Edges & Vertices", ITK_LOCATION);
+                throw e;
+            }
+
+            //sum up all meshes
+            for (unsigned j = 0; j < meanMesh->GetNumberOfPoints(); j++) {
+                typename MeshType::PointType point = meanMesh->GetPoint(j);
+                typename MeshType::PointType pointToAdd = mesh->GetPoint(j);
+                for (unsigned k = 0; k < meanMesh->GetPoint(j).Size(); k++) {
+                    point[k] = point[k] + pointToAdd[k];
+                }
+                meanMesh->SetPoint(j, point);
+            }
+        }
+    }
+
+    //divide by the # of meshes
+    for (unsigned j = 0; j < meanMesh->GetNumberOfPoints(); j++) {
+        typename MeshType::PointType point = meanMesh->GetPoint(j);
+        for (unsigned k = 0; k < meanMesh->GetPoint(j).Size(); k++) {
+            point[k] /= meshes.size();
+        }
+        meanMesh->SetPoint(j, point);
+    }
+
+    return meanMesh;
+}
+
+
+StringList getFileList(std::string path) {
+    StringList fileList;
+
+    ifstream file;
+    try {
+        file.exceptions(ifstream::failbit | ifstream::badbit);
+        file.open(path.c_str(), ifstream::in);
+        string line;
+        while (getline(file, line)) {
+            if (line != "") {
+                fileList.push_back(line);
+            }
+        }
+    } catch (ifstream::failure e) {
+        if (file.eof() == 0) {
+            throw e;
+        }
+    }
+    file.close();
+    return fileList;
+}

--- a/modules/ITK/cli/statismo-build-shape-model.cxx
+++ b/modules/ITK/cli/statismo-build-shape-model.cxx
@@ -1,0 +1,179 @@
+#include <sys/types.h>
+#include <errno.h>
+#include <iostream>
+#include <string>
+
+#include <itkDirectory.h>
+#include <itkMesh.h>
+#include <itkMeshFileWriter.h>
+#include <itkMeshFileReader.h>
+
+#include "itkDataManager.h"
+#include "itkPCAModelBuilder.h"
+#include "itkStandardMeshRepresenter.h"
+#include "itkStatisticalModel.h"
+
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace po = boost::program_options;
+using namespace std;
+
+
+struct programOptions {
+    bool bDisplayHelp;
+    string strDataListFile;
+    string strProcrustesMode;
+    string strProcrustesReferenceFile;
+    string strOutputFileName;
+    float fNoiseVariance;
+    bool bAutoNoise;
+};
+typedef list<string> StringList;
+
+po::options_description initializeProgramOptions(programOptions& poParameters);
+bool isOptionsConflictPresent(programOptions opt);
+StringList getFileList(programOptions opt);
+void buildAndSaveShapeModel(programOptions opt);
+
+int main(int argc, char** argv) {
+    programOptions poParameters;
+
+    po::positional_options_description optPositional;
+    optPositional.add("output-file", 1);
+    po::options_description optAllOptions = initializeProgramOptions(poParameters);
+
+
+    po::variables_map vm;
+    try {
+        po::parsed_options parsedOptions = po::command_line_parser(argc, argv).options(optAllOptions).positional(optPositional).run();
+        po::store(parsedOptions, vm);
+        po::notify(vm);
+    } catch (po::error& e) {
+        cerr << "An exception occurred while parsing the Command line:"<<endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (poParameters.bDisplayHelp == true) {
+        cout << optAllOptions << endl;
+        return EXIT_SUCCESS;
+    }
+    if (isOptionsConflictPresent(poParameters) == true)	{
+        cerr << "A conflict in the options exists or insufficient options were set." << endl;
+        cout << optAllOptions << endl;
+        return EXIT_FAILURE;
+    }
+
+    try {
+        buildAndSaveShapeModel(poParameters);
+    } catch (ifstream::failure & e) {
+        cerr << "Could not read the data-list:" << endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    } catch (itk::ExceptionObject & e) {
+        cerr << "Could not build the model:" << endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+bool isOptionsConflictPresent(programOptions opt) {
+    boost::algorithm::to_lower(opt.strProcrustesMode);
+    if(opt.strProcrustesMode == "reference" && opt.strProcrustesReferenceFile == "") {
+        return true;
+    }
+
+    if (opt.strDataListFile == "" || opt.strOutputFileName == "") {
+        return true;
+    }
+
+    if (opt.strProcrustesMode != "gpa" && opt.strProcrustesMode != "reference") {
+        return true;
+    }
+
+    return false;
+}
+
+void buildAndSaveShapeModel(programOptions opt) {
+    const unsigned Dimensions = 3;
+    typedef itk::Mesh<float, Dimensions> MeshType;
+    typedef itk::StandardMeshRepresenter<float, Dimensions> RepresenterType;
+    typedef itk::PCAModelBuilder<MeshType> PCAModelBuilder;
+    typedef itk::StatisticalModel<MeshType> StatisticalModelType;
+    typedef itk::DataManager<MeshType> DataManagerType;
+    typedef itk::MeshFileReader<MeshType> MeshReaderType;
+    typedef list<MeshType::Pointer> MeshList;
+
+    RepresenterType::Pointer representer = RepresenterType::New();
+    DataManagerType::Pointer dataManager = DataManagerType::New();
+
+
+    if (opt.strProcrustesMode == "reference") {
+        MeshReaderType::Pointer refReader = MeshReaderType::New();
+        refReader->SetFileName(opt.strProcrustesReferenceFile);
+        refReader->Update();
+        representer->SetReference(refReader->GetOutput());
+    } else {
+        //TODO: calculate mean & use that as reference
+        itk::ExceptionObject e(__FILE__, __LINE__, "GPA is currently not implemented", ITK_LOCATION);
+        throw e;
+    }
+
+    dataManager->SetRepresenter(representer);
+
+    StringList filenames = getFileList(opt);
+    MeshList meshes;
+    for (StringList::const_iterator it = filenames.begin(); it != filenames.end(); it++) {
+        MeshReaderType::Pointer reader = MeshReaderType::New();
+        reader->SetFileName(it->c_str());
+        reader->Update();
+        MeshType::Pointer mesh = reader->GetOutput();
+        dataManager->AddDataset(mesh, it->c_str());
+    }
+
+
+
+
+    StatisticalModelType::Pointer model;
+    PCAModelBuilder::Pointer pcaModelBuilder = PCAModelBuilder::New();
+    model = pcaModelBuilder->BuildNewModel(dataManager->GetData(), opt.fNoiseVariance);
+    model->Save(opt.strOutputFileName.c_str());
+}
+
+StringList getFileList(programOptions opt) {
+    StringList fileList;
+
+    ifstream file;
+    file.exceptions(ifstream::failbit | ifstream::badbit);
+    file.open(opt.strDataListFile.c_str(), ifstream::in);
+    string line;
+    while (getline(file, line)) {
+        if (line != "") {
+            fileList.push_back(line);
+        }
+    }
+    return fileList;
+}
+
+po::options_description initializeProgramOptions(programOptions& poParameters) {
+    po::options_description optMandatory("Mandatory options");
+    optMandatory.add_options()
+    ("data-list,d", po::value<string>(&poParameters.strDataListFile), "File containing a list of meshes to build shape model from")
+    ("output-file,o", po::value<string>(&poParameters.strOutputFileName), "Name of the output file")
+    ;
+    po::options_description optAdditional("Optional options");
+    optAdditional.add_options()
+    ("procrustes,p", po::value<string>(&poParameters.strProcrustesMode)->default_value("GPA"), "Specify how the data is aligned. PROCRUSTES_MODE can be reference (aligns all datasets rigidly to the reference) GPA alignes all the datasets to the population mean. This option is only available when TYPE is shape.")
+    ("reference,r", po::value<string>(&poParameters.strProcrustesReferenceFile), "Specify the reference used for model building. This is needed in the caes that PROCRUSTES-MODE is reference")
+    ("noise", po::value<float>(&poParameters.fNoiseVariance)->default_value(0), "Noise variance of the PPCA model")
+//		("auto-noise", po::bool_switch(&poParameters.bAutoNoise), "Estimate noise directly from dropped components") //currently not available
+    ("help,h", po::bool_switch(&poParameters.bDisplayHelp), "Display this help message")
+    ;
+
+    po::options_description optAllOptions;
+    optAllOptions.add(optMandatory).add(optAdditional);
+    return optAllOptions;
+}

--- a/modules/ITK/cli/statismo-build-shape-model.md
+++ b/modules/ITK/cli/statismo-build-shape-model.md
@@ -22,24 +22,24 @@ In this case the file data.txt contains a list of filenames of meshes (which are
 # OPTIONS
 
 -d, \--data-list *DATA_LIST*
-:	*DATA_LIST* is the path to a file containing a list of mesh-files that will be used to create the shape model. Please only give the path to **one** mesh-file per line.
+:	*DATA_LIST* is the path to a file containing a list of mesh-files that will be used to create the shape model. Please only give the path to **one** mesh-file per line  in the data-list-file.
 
 -o, \--output-file *OUTPUT_FILE*
 :	*OUTPUT_FILE* is the path where the newly build model should be saved.
 
 -p, \--procrustes *PROCRUSTES_MODE*
-:	Specify how the data is aligned. *PROCRUSTES_MODE* can be **reference** (aligns all datasets rigidly to the reference) **GPA** alignes all the datasets to the population mean. This option is only available when *TYPE* is `shape`.
+:	Specify how the data is aligned. *PROCRUSTES_MODE* can be **reference** which aligns all datasets rigidly to the reference or **GPA** which aligns all the datasets to the population mean.
 
 -r, \--reference *FILE* 
-:	Specify the reference used for model building. This is needed in the caes that *PROCRUSTES-MODE* is `reference`
+:	Specify the reference used for model building. This is needed if *PROCRUSTES-MODE* is **reference**
 
---noise *NOISE*
+-n, \--noise *NOISE*
 :	Specify the noise variance of the PPCA model. Defaults to 0
 
- <!---
-\--auto-noise 
+ <!-- 
+-a, \--auto-noise 
 :	Estimate noise directly from dropped components.
---->
+-->
  
 # Examples 
 Build a model where the datasets are aligned to the procrustes mean
@@ -53,3 +53,11 @@ Build a model where the datasets are aligned to a given reference
 
 # SEE ALSO
 
+*statismo-build-deformation-model* (8).
+Builds deformation models from a list of deformation fields
+
+*statismo-build-gp-model* (8).
+Builds shape or deformation models from a given gaussian process definition.
+
+*statismo-sample* (8).
+Draws samples from a model.

--- a/modules/ITK/cli/statismo-build-shape-model.md
+++ b/modules/ITK/cli/statismo-build-shape-model.md
@@ -1,0 +1,55 @@
+% STATISMO-BUILD-SHAPE-MODEL(8)
+
+# NAME
+
+statismo-build-shape-model - builds shape models from a list of meshes
+
+# SYNOPSIS
+
+statismo-buid-shape-model [*options*] *output-file*
+
+# DESCRIPTION
+
+statismo-build-model is used to build a shape model from a given list of meshes. 
+**The meshes have to be in correspondence**.
+
+In the simplest case, a model can be built from existing meshes with the following command
+
+    statismo-build-shape-model --data-list data.txt shapemodel.h5
+
+In this case the file data.txt contains a list of filenames of meshes (which are already in correspondence) and writes a model called shapemodel.h5
+
+# OPTIONS
+
+-d, \--data-list *DATA_LIST*
+:	*DATA_LIST* is the path to a file containing a list of mesh-files that will be used to create the shape model. Please only give the path to **one** mesh-file per line.
+
+-o, \--output-file *OUTPUT_FILE*
+:	*OUTPUT_FILE* is the path where the newly build model should be saved.
+
+-p, \--procrustes *PROCRUSTES_MODE*
+:	Specify how the data is aligned. *PROCRUSTES_MODE* can be **reference** (aligns all datasets rigidly to the reference) **GPA** alignes all the datasets to the population mean. This option is only available when *TYPE* is `shape`.
+
+-r, \--reference *FILE* 
+:	Specify the reference used for model building. This is needed in the caes that *PROCRUSTES-MODE* is `reference`
+
+--noise *NOISE*
+:	Specify the noise variance of the PPCA model. Defaults to 0
+
+ <!---
+\--auto-noise 
+:	Estimate noise directly from dropped components.
+--->
+ 
+# Examples 
+Build a model where the datasets are aligned to the procrustes mean
+
+    statismo-build-shape-model -p GPA --data-list data.txt shapemodel.h5
+
+Build a model where the datasets are aligned to a given reference
+
+    statismo-build-shape-model --procrustes=reference --reference=ref.vtk --data-list data.txt shapemodel.h5
+
+
+# SEE ALSO
+

--- a/modules/ITK/cli/statismo-sample.cxx
+++ b/modules/ITK/cli/statismo-sample.cxx
@@ -1,0 +1,209 @@
+#include <iostream>
+#include <string>
+#include <set>
+
+#include <itkDirectory.h>
+#include <itkMesh.h>
+#include <itkMeshFileWriter.h>
+#include <itkMeshFileReader.h>
+#include <itkImage.h>
+
+#include "itkDataManager.h"
+#include "itkStandardMeshRepresenter.h"
+#include "itkStandardImageRepresenter.h"
+#include "itkStatisticalModel.h"
+
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace po = boost::program_options;
+using namespace std;
+
+typedef vector<string> StringList;
+
+struct programOptions {
+    bool bDisplayHelp;
+    string strInputFileName;
+    string strOutputFileName;
+    string strType;
+    StringList vParameters;
+    bool bSampleMean;
+    bool bSampleReference;
+};
+
+po::options_description initializeProgramOptions(programOptions& poParameters);
+bool isOptionsConflictPresent(programOptions& opt);
+template <class DataType, class RepresenterType, class DataWriterType>
+void drawSampleFromModel(programOptions opt);
+template <class VectorType>
+void populateVectorWithParameters(const StringList& vParams, VectorType& vParametersReturnVector);
+
+
+
+int main(int argc, char** argv) {
+    programOptions poParameters;
+
+    po::positional_options_description optPositional;
+    optPositional.add("output-file", 1);
+    po::options_description optAllOptions = initializeProgramOptions(poParameters);
+
+
+    po::variables_map vm;
+    try {
+        po::parsed_options parsedOptions = po::command_line_parser(argc, argv).options(optAllOptions).positional(optPositional).run();
+        po::store(parsedOptions, vm);
+        po::notify(vm);
+    } catch (po::error& e) {
+        cerr << "An exception occurred while parsing the Command line:"<<endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    if (poParameters.bDisplayHelp == true) {
+        cout << optAllOptions << endl;
+        return EXIT_SUCCESS;
+    }
+    if (isOptionsConflictPresent(poParameters) == true)	{
+        cerr << "A conflict in the options exists or insufficient options were set." << endl;
+        cout << optAllOptions << endl;
+        return EXIT_FAILURE;
+    }
+
+    try {
+        const unsigned Dimensions = 3;
+        if (poParameters.strType == "shape") {
+
+            typedef itk::Mesh<float, Dimensions> DataType;
+            typedef itk::StandardMeshRepresenter<float, Dimensions> RepresenterType;
+            typedef itk::MeshFileWriter<DataType> DataWriterType;
+            drawSampleFromModel<DataType, RepresenterType, DataWriterType>(poParameters);
+        } else {
+            typedef itk::Image< itk::Vector<float, Dimensions>, Dimensions > DataType;
+            typedef itk::StandardImageRepresenter<itk::Vector<float, Dimensions>, Dimensions> RepresenterType;
+            typedef itk::ImageFileWriter<DataType> DataWriterType;
+            drawSampleFromModel<DataType, RepresenterType, DataWriterType>(poParameters);
+        }
+    } catch (itk::ExceptionObject & e) {
+        cerr << "Could not build the model:" << endl;
+        cerr << e.what() << endl;
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+bool isOptionsConflictPresent(programOptions& opt) {
+    boost::algorithm::to_lower(opt.strType);
+
+    if (opt.bSampleMean + (opt.vParameters.size() > 0) + opt.bSampleReference > 1) {
+        return true;
+    }
+
+    if (opt.strInputFileName == "" || opt.strOutputFileName == "") {
+        return true;
+    }
+
+    if (opt.strType != "shape" && opt.strType != "deformation") {
+        return true;
+    }
+
+    if (opt.strInputFileName == opt.strOutputFileName) {
+        return true;
+    }
+
+    return false;
+}
+
+
+template <class VectorType>
+void populateVectorWithParameters(const StringList& vParams, VectorType& vParametersReturnVector) {
+    set<unsigned> sSeenIndices;
+
+    for (StringList::const_iterator i = vParams.begin(); i != vParams.end(); i++) {
+        StringList vSplit;
+        bool bSuccess = true;
+        boost::split(vSplit, *i, boost::is_any_of(":"));
+        if (vSplit.size() != 2) {
+            bSuccess = false;
+        } else {
+            try {
+                unsigned uIndex = boost::lexical_cast<unsigned>(vSplit[0]);
+                double dValue = boost::lexical_cast<double>(vSplit[1]);
+
+                if (uIndex >= vParametersReturnVector.size()) {
+                    itk::ExceptionObject e(__FILE__, __LINE__, "The parameter '" + *i + "' is has an index value that is not in the range of this model's available parameters (0 to " + boost::lexical_cast<string>(vParametersReturnVector.size()) + ").", ITK_LOCATION);
+                    throw e;
+                }
+
+                if (sSeenIndices.find(uIndex) == sSeenIndices.end()) {
+                    sSeenIndices.insert(uIndex);
+                    vParametersReturnVector[uIndex] = dValue;
+                } else {
+                    itk::ExceptionObject e(__FILE__, __LINE__, "The index '" + boost::lexical_cast<string>(uIndex) +"' occurs more than once in the parameter list.", ITK_LOCATION);
+                    throw e;
+                }
+            } catch (boost::bad_lexical_cast &) {
+                bSuccess = false;
+            }
+        }
+
+        if (bSuccess == false) {
+            itk::ExceptionObject e(__FILE__, __LINE__, "The parameter '" + *i + "' is in an incorrect format. The correct format is index:value. Like for example 0:1.1 or 19:-2", ITK_LOCATION);
+            throw e;
+        }
+    }
+}
+
+template <class DataType, class RepresenterType, class DataWriterType>
+void drawSampleFromModel(programOptions opt) {
+    typedef itk::StatisticalModel<DataType> StatisticalModelType;
+
+    typename RepresenterType::Pointer pRepresenter = RepresenterType::New();
+    typename StatisticalModelType::Pointer pModel = StatisticalModelType::New();
+
+    pModel->Load(pRepresenter, opt.strInputFileName.c_str());
+
+    typename DataType::Pointer output;
+    if (opt.bSampleMean == true) {
+        output = pModel->DrawMean();
+    } else if (opt.vParameters.size() > 0) {
+        unsigned uNrOfParameters = pModel->GetNumberOfPrincipalComponents();
+        typename StatisticalModelType::VectorType vModelParameters(uNrOfParameters);
+        vModelParameters.fill(0);
+
+        populateVectorWithParameters<typename StatisticalModelType::VectorType>(opt.vParameters, vModelParameters);
+
+        output = pModel->DrawSample(vModelParameters);
+    } else if (opt.bSampleReference == true) {
+        output = pModel->GetRepresenter()->GetReference();
+    } else {
+        output = pModel->DrawSample();
+    }
+
+    typename DataWriterType::Pointer pDataWriter = DataWriterType::New();
+    pDataWriter->SetFileName(opt.strOutputFileName.c_str());
+    pDataWriter->SetInput(output);
+    pDataWriter->Update();
+}
+
+
+po::options_description initializeProgramOptions(programOptions& poParameters) {
+    po::options_description optMandatory("Mandatory options");
+    optMandatory.add_options()
+    ("type,t", po::value<string>(&poParameters.strType)->default_value("shape"), "Specifies the type of the model: shape and deformation are the two available types")
+
+    ("iput-file,i", po::value<string>(&poParameters.strInputFileName), "The path to the model file.")
+    ("output-file,o", po::value<string>(&poParameters.strOutputFileName), "Name of the output file/the sample.")
+    ;
+    po::options_description optAdditional("Optional options");
+    optAdditional.add_options()
+    ("mean,m", po::bool_switch(&poParameters.bSampleMean), "Draws the mean from the model and saves it.")
+    ("reference,r", po::bool_switch(&poParameters.bSampleReference), "Draws the reference from the model and saves it.")
+    ("parameters,p", po::value<StringList >(&poParameters.vParameters)->multitoken(), "Makes it possible to specify a list of parameters and their positions that will then be used to draw a sample. Parameters are speciefied in the following format: POSITION1:VALUE1 POSITIONn:VALUEn. Unspecified parameters will be set to 0.")
+    ("help,h", po::bool_switch(&poParameters.bDisplayHelp), "Display this help message")
+    ;
+
+    po::options_description optAllOptions;
+    optAllOptions.add(optMandatory).add(optAdditional);
+    return optAllOptions;
+}

--- a/modules/ITK/cli/statismo-sample.md
+++ b/modules/ITK/cli/statismo-sample.md
@@ -1,0 +1,74 @@
+% STATISMO-SAMPLE(8)
+
+# NAME
+
+statismo-sample - draws samples from a model
+
+# SYNOPSIS
+
+statismo-sample [*options*] -i *input-file* *output-file*
+
+# DESCRIPTION
+
+statismo-sample is used to draw samples from a model. It's possible to draw different samples such as the mean, a random sample or a sample with given parameters.
+
+# OPTIONS
+
+-m, \--mean 
+:	Draws the mean from the model and saves it.
+
+-r, \--reference 
+:	Draws the reference from the model and saves it.
+
+-p, \--parameters *PARAMETERS*
+:	*PARAMETERS* is a list of parameters and their position that will be used to draw a sample. Parameters are speciefied in the following format: **POSITION1**:**VALUE1** **POSITIONn**:**VALUEn**. Unspecified parameters will be set to 0.
+
+-t, \--type *TYPE*
+:	Specifies the type of the model. *TYPE* can either be **shape** or **deformation**.
+
+-i, \--input-file *MODEL_FILE*
+:	*MODEL_FILE* is the path to the model.
+
+-o, \--output-file *OUTPUT_FILE*
+:	*OUTPUT_FILE* is the path where the sample will be saved.
+
+
+
+
+ 
+# Examples 
+Draw a random sample from a shape model:
+
+    statismo-sample -i model.h5 sample.vtk
+
+or
+
+    statismo-sample -i model.h5 -o sample.vtk
+
+Draw a random sample from a deformation model:
+
+    statismo-sample -t deformation -i model.h5 -o sample.vtk
+
+Draw the mean from a shape model:
+
+    statismo-sample -m -i model.h5 mean.vtk
+	
+Draw the reference from a shape model:
+
+    statismo-sample -r -i model.h5 mean.vtk
+
+Draw a sample from a shape model with the 1st parameter set to 1, the 5th parameter set to 0.1 and the 10th parameter set to 2.5:
+
+    statismo-sample -p 0:1 4:0.1 9:2.5 -i model.h5 sample.vtk
+
+# SEE ALSO
+
+
+*statismo-build-shape-model* (8).
+Builds shape models from a list of meshes.
+
+*statismo-build-deformation-model* (8).
+Builds deformation models from a list of deformation fields
+
+*statismo-build-gp-model* (8).
+Builds shape or deformation models from a given gaussian process definition.

--- a/superbuild/External-Boost.cmake
+++ b/superbuild/External-Boost.cmake
@@ -35,7 +35,7 @@ ExternalProject_Add(Boost
   URL_MD5 ${Boost_md5}
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ${Boost_Bootstrap_Command} --prefix=${INSTALL_DEPENDENCIES_DIR}/lib
-  BUILD_COMMAND ${Boost_b2_Command} install -j8   --prefix=${INSTALL_DEPENDENCIES_DIR} --with-thread --with-system --with-date_time address-model=${Boost_address_model}
+  BUILD_COMMAND ${Boost_b2_Command} install -j8   --prefix=${INSTALL_DEPENDENCIES_DIR} --with-thread --with-system --with-date_time --with-program_options address-model=${Boost_address_model}
   INSTALL_COMMAND ""
 )
 


### PR DESCRIPTION
**This pull request isn't meant to be accepted, but serves to receive some feedback**

I was asked by @marcelluethi if I'd be up to write a few CLI tools for statismo.

On the current status:
* I have set up cmake to install a manpage/help file for each command on *nix (and cygwin) and install it (as a html in a subfolder in the bin dir on windows or man 8 *COMMAND HERE* on linux) 
* cmake will of course also install the binary
* I have only tested things on windows (VS 2013) & linux (arch) so far. Whether man pages -among other things - are being installed correctly on OS X is unknown to me at this time.
* The only available CLI tool at this moment is *statismo-build-shape-model* and it's incomplete as of right now (it only allows for models to be built with a reference; GPA is unavailable in this pull request)
* Pandoc is used to convert each command's documentation from markdown to other formats such as html or man pages. (cmake will not download it if it's missing from a system - documentation will only be generated if pandoc is present)


~Frank

Edit://
As it turns out I messed up in the file statismo-build-shape-model.cxx:
the following line needs to be removed (getline throws an exception when it reaches EOF):
	file.exceptions(ifstream::failbit | ifstream::badbit);