### PR TITLE
Add fix to allow packaging for ubuntu vivid

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: statismo
 Section: utils
 Priority: extra
 Maintainer: Stefan Schlager <zarquon42@gmail.com>
-Build-Depends: debhelper (>= 9), libinsighttoolkit4-dev, libvtk5-dev, libhdf5-dev, libeigen3-dev, libboost-date-time-dev, libboost-dev, libboost-system-dev, libboost-thread-dev, cmake, libfftw3-dev, doxygen, graphviz, python2.7-dev, wget, gnuplot, qtbase5-dev
+Build-Depends: debhelper (>= 9), libinsighttoolkit4-dev, libvtk5-dev, libhdf5-dev, libeigen3-dev, libboost-date-time-dev, libboost-dev, libboost-system-dev, libboost-thread-dev, cmake, libfftw3-dev, doxygen, graphviz, python2.7-dev, wget, gnuplot, qtbase5-dev, libqt5opengl5-dev, libqt5webkit5-dev
 Homepage: https://github.com/statismo/statismo
 Standards-Version: 3.9.5
 

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Description: Statismo is a c++ framework for statistical shape modeling. This pa
 
 Package: statismo-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, statismo-core, libvtk5-dev, qtbase5-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, statismo-core, libvtk5-dev
 Recommends: libinsighttoolkit4-dev, libhdf5-dev, libeigen3-dev, libboost-date-time-dev, libboost-dev, libboost-system-dev , libboost-thread-dev, cmake, libfftw3-dev
 Suggests: statismo-doc, statismo-example-data
 Description: Statismo is a c++ framework for statistical shape modeling. This package contains the header files for statismo.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: statismo
 Section: utils
 Priority: extra
 Maintainer: Stefan Schlager <zarquon42@gmail.com>
-Build-Depends: debhelper (>= 9), libinsighttoolkit4-dev, libvtk5-dev, libhdf5-dev, libeigen3-dev, libboost-date-time-dev, libboost-dev, libboost-system-dev, libboost-thread-dev, cmake, libfftw3-dev, doxygen, graphviz, python2.7-dev
+Build-Depends: debhelper (>= 9), libinsighttoolkit4-dev, libvtk5-dev, libhdf5-dev, libeigen3-dev, libboost-date-time-dev, libboost-dev, libboost-system-dev, libboost-thread-dev, cmake, libfftw3-dev, doxygen, graphviz, python2.7-dev, wget, gnuplot, qtbase5-dev
 Homepage: https://github.com/statismo/statismo
 Standards-Version: 3.9.5
 

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Description: Statismo is a c++ framework for statistical shape modeling. This pa
 
 Package: statismo-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, statismo-core, libvtk5-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, statismo-core, libvtk5-dev, qtbase5-dev
 Recommends: libinsighttoolkit4-dev, libhdf5-dev, libeigen3-dev, libboost-date-time-dev, libboost-dev, libboost-system-dev , libboost-thread-dev, cmake, libfftw3-dev
 Suggests: statismo-doc, statismo-example-data
 Description: Statismo is a c++ framework for statistical shape modeling. This package contains the header files for statismo.

--- a/debian/switch-release.sh
+++ b/debian/switch-release.sh
@@ -30,10 +30,10 @@ cd $DIR
 echo $DIR
 cp -f changelog changelog.bck
 cp -f control control.bck
-cp -f ../CMakeLists.txt ../CMakeLists.txt.bck
-if [ $vtk == 6 ]; then
-sed -i 's|find_package( VTK REQUIRED )|find_package( VTK REQUIRED )\n  find_package(Qt5Widgets REQUIRED)|g' ../CMakeLists.txt
-fi
+#cp -f ../CMakeLists.txt ../CMakeLists.txt.bck
+#if [ $vtk == 6 ]; then
+#sed -i 's|find_package( VTK REQUIRED )|find_package( VTK REQUIRED )\n  find_package(Qt5Widgets REQUIRED) \n  find_package(Qt5OpenGL REQUIRED)|g' ../CMakeLists.txt
+#fi
 vtk=libvtk$vtk-dev
 echo $vtk
 sed -i "s|libvtk5-dev|$vtk|g" control
@@ -43,5 +43,5 @@ debuild -S -I
 cd debian
 mv changelog.bck changelog
 mv control.bck control
-mv ../CMakeLists.txt.bck ../CMakeLists.txt
+#mv ../CMakeLists.txt.bck ../CMakeLists.txt
 

--- a/debian/switch-release.sh
+++ b/debian/switch-release.sh
@@ -30,6 +30,10 @@ cd $DIR
 echo $DIR
 cp -f changelog changelog.bck
 cp -f control control.bck
+cp -f ../CMakeLists.txt ../CMakeLists.txt.bck
+if [ $vtk == 6 ]; then
+sed -i 's|find_package( VTK REQUIRED )|find_package( VTK REQUIRED )\n  find_package(Qt5Widgets REQUIRED)|g' ../CMakeLists.txt
+fi
 vtk=libvtk$vtk-dev
 echo $vtk
 sed -i "s|libvtk5-dev|$vtk|g" control
@@ -39,4 +43,5 @@ debuild -S -I
 cd debian
 mv changelog.bck changelog
 mv control.bck control
+mv ../CMakeLists.txt.bck ../CMakeLists.txt
 

--- a/modules/VTK/src/CMakeLists.txt
+++ b/modules/VTK/src/CMakeLists.txt
@@ -1,11 +1,25 @@
+##macro that removes all linking to Qt libs
+macro(NO_QT arg result)
+  set(VTK_NO_QT "")
+  foreach(lib ${arg})
+    if (NOT  ${lib} MATCHES "Qt")
+      list(APPEND VTK_NO_QT ${lib})
+    endif()
+  endforeach()
+  set(${result} "${VTK_NO_QT}")
+endmacro()
+
+NO_QT("${VTK_LIBRARIES}" VTK_LIBRARIES)
+
 add_library( statismo_VTK ${statismo_LIB_TYPE}
   vtkStandardMeshRepresenter.cxx
   vtkUnstructuredGridRepresenter.cxx
 )
+
 target_link_libraries( statismo_VTK
   statismo_core
   ${VTK_LIBRARIES}
-)
+  )
 
 set_target_properties( statismo_VTK PROPERTIES
   DEBUG_POSTFIX "-d"


### PR DESCRIPTION
Fixes #189 . Adaption of dependencies for ubuntu vivid and a hack in the script, temporarily modifying CMakeList.txt during package creation.