### PR TITLE
Cli minor fixes

### DIFF
--- a/modules/ITK/cli/statismo-build-gp-model.cxx
+++ b/modules/ITK/cli/statismo-build-gp-model.cxx
@@ -136,11 +136,8 @@ bool isOptionsConflictPresent(programOptions& opt) {
         return true;
     }
 
-    if (opt.strOptionalModelPath == "" && opt.strReferenceFile == "") {
-        return true;
-    }
-
-    if (opt.strOptionalModelPath != "" & opt.strReferenceFile != "") {
+    if ((opt.strOptionalModelPath == "" && opt.strReferenceFile == "")
+            || (opt.strOptionalModelPath != "" & opt.strReferenceFile != "")) {
         return true;
     }
 

--- a/modules/ITK/cli/statismo-build-gp-model.cxx
+++ b/modules/ITK/cli/statismo-build-gp-model.cxx
@@ -136,7 +136,16 @@ bool isOptionsConflictPresent(programOptions& opt) {
         return true;
     }
 
-    if (opt.strOutputFileName == "" || opt.strReferenceFile == "") {
+    if (opt.strOptionalModelPath == "" && opt.strReferenceFile == "") {
+        return true;
+    }
+
+    if (opt.strOptionalModelPath != "" & opt.strReferenceFile != "") {
+        return true;
+    }
+
+
+    if (opt.strOutputFileName == "") {
         return true;
     }
 
@@ -155,6 +164,7 @@ bool isOptionsConflictPresent(programOptions& opt) {
     if (opt.strType == "shape" && opt.uNumberOfDimensions != 3) {
         return true;
     }
+
 
     return false;
 }
@@ -188,10 +198,15 @@ void buildAndSaveModel(programOptions opt) {
 
     typedef statismo::StatisticalModel<DataType> RawModelType;
     typedef boost::shared_ptr<RawModelType> RawModelPointerType;
+    typedef typename RepresenterType::DatasetPointerType DatasetPointerType;
+
     RawModelPointerType pRawStatisticalModel;
+    typename RepresenterType::Pointer pRepresenter = RepresenterType::New();
+    DatasetPointerType pMean;
+
+
     if(opt.strOptionalModelPath != "") {
 		try{
-			typename RepresenterType::Pointer pRepresenter = RepresenterType::New();
 			pRawStatisticalModel.reset(RawModelType::Load(pRepresenter.GetPointer(), opt.strOptionalModelPath.c_str()));
 			pStatModelKernel.reset(new statismo::StatisticalModelKernel<DataType>(pRawStatisticalModel.get()));
 			pModelBuildingKernel.reset(new statismo::SumKernel<PointType>(pStatModelKernel.get(), pScaledKernel.get()));
@@ -199,16 +214,19 @@ void buildAndSaveModel(programOptions opt) {
 		catch (statismo::StatisticalModelException& s) {
 			itkGenericExceptionMacro(<< "Failed to read the optional model: "<< s.what());
 		}
+        pMean = pRawStatisticalModel->DrawMean();
     } else {
         pModelBuildingKernel = pScaledKernel;
+        typename DataReaderType::Pointer pReferenceReader = DataReaderType::New();
+        pReferenceReader->SetFileName(opt.strReferenceFile);
+        pReferenceReader->Update();
+        pRepresenter->SetReference(pReferenceReader->GetOutput());
+        pMean = pRepresenter->IdentitySample();
+
     }
 
-    typename DataReaderType::Pointer pReferenceReader = DataReaderType::New();
-    pReferenceReader->SetFileName(opt.strReferenceFile);
-    pReferenceReader->Update();
 
-    typename RepresenterType::Pointer pRepresenter = RepresenterType::New();
-    pRepresenter->SetReference(pReferenceReader->GetOutput());
+
 
     typedef itk::LowRankGPModelBuilder<DataType> ModelBuilderType;
     typename ModelBuilderType::Pointer gpModelBuilder = ModelBuilderType::New();
@@ -217,11 +235,7 @@ void buildAndSaveModel(programOptions opt) {
 
     typedef itk::StatisticalModel<DataType> StatisticalModelType;
     typename StatisticalModelType::Pointer pModel;
-    if (isShapeModel == true) {
-        pModel = gpModelBuilder->BuildNewModel(pReferenceReader->GetOutput(), *pModelBuildingKernel.get(), opt.iNrOfBasisFunctions);
-    } else {
-        pModel = gpModelBuilder->BuildNewZeroMeanModel(*pModelBuildingKernel.get(), opt.iNrOfBasisFunctions);
-    }
+    pModel = gpModelBuilder->BuildNewModel(pMean, *pModelBuildingKernel.get(), opt.iNrOfBasisFunctions);
 
     pModel->Save(opt.strOutputFileName.c_str());
 }
@@ -252,14 +266,15 @@ po::options_description initializeProgramOptions(programOptions& poParameters) {
     ("kernel,k", po::value<string>(&poParameters.strKernel), kernelHelp.c_str())
     ("parameters,p", po::value<vector<string> >(&poParameters.vKernelParameters)->multitoken(), "Specifies the kernel parameters. The Parameters depend on the kernel")
     ("scale,s", po::value<float>(&poParameters.fKernelScale)->default_value(1), "A Scaling factor with which the Kernel will be scaled")
-    ("numberofbasisfunctions,n", po::value<int>(&poParameters.iNrOfBasisFunctions)->default_value(25), "Number of basis functions/parameters the model will have")
-    ("reference,r", po::value<string>(&poParameters.strReferenceFile), "The reference that will be used to build the model")
+    ("numberofbasisfunctions,n", po::value<int>(&poParameters.iNrOfBasisFunctions), "Number of basis functions/parameters the model will have")
     ("output-file,o", po::value<string>(&poParameters.strOutputFileName), "Name of the output file where the model will be saved")
     ;
     po::options_description optAdditional("Optional options");
     optAdditional.add_options()
+    ("reference,r", po::value<string>(&poParameters.strReferenceFile), "The reference that will be used to build the model")
     ("input-model,m", po::value<string>(&poParameters.strOptionalModelPath), "Extends an existing model with data from the specified kernel. This is useful to extend existing models in case of insufficient data.")
     ("help,h", po::bool_switch(&poParameters.bDisplayHelp), "Display this help message")
+
     ;
 
     po::options_description optAllOptions;

--- a/modules/ITK/cli/statismo-build-gp-model.md
+++ b/modules/ITK/cli/statismo-build-gp-model.md
@@ -55,6 +55,7 @@ statismo-build-gp-model is used to build a shape or deformation model from a gau
 :	*MODEL_FILE* Extends an existing model with data from the specified kernel. This is useful to extend existing models in case of insufficient data.
 
 
+
 # Examples 
 
 Build a shape model with a gaussian kernel and 50 basis functions:

--- a/modules/ITK/cli/statismo-fit-image.cxx
+++ b/modules/ITK/cli/statismo-fit-image.cxx
@@ -302,8 +302,8 @@ po::options_description initializeProgramOptions(programOptions& poParameters) {
     optMandatory.add_options()
 
     ("input-model,i", po::value<string>(&poParameters.strInputModelFileName), "The path to the model file.")
-    ("input-movingimage,m", po::value<string>(&poParameters.strInputMovingImageFileName), "The path to the moving image.")
-    ("input-fixedimage,f", po::value<string>(&poParameters.strInputFixedImageFileName), "The path to the fixed image.")
+    ("moving-image,m", po::value<string>(&poParameters.strInputMovingImageFileName), "The path to the moving image.")
+    ("fixed-image,f", po::value<string>(&poParameters.strInputFixedImageFileName), "The path to the fixed image.")
     ("dimensionality,d", po::value<unsigned>(&poParameters.uNumberOfDimensions)->default_value(3), "Dimensionality of the input images & model")
     ("regularization-weight,w", po::value<double>(&poParameters.dRegularizationWeight), "This is the regularization weight to make sure the model parameters don't don't get too big while fitting.")
     ;
@@ -317,8 +317,8 @@ po::options_description initializeProgramOptions(programOptions& poParameters) {
 
     po::options_description optLandmarks("Landmarks (optional - if you set one you have to set all)");
     optLandmarks.add_options()
-    ("landmarks-fixed", po::value<string>(&poParameters.strInputFixedLandmarksFileName), "Name of the file where the fixed Landmarks are saved.")
-    ("landmarks-moving", po::value<string>(&poParameters.strInputMovingLandmarksFileName), "Name of the file where the moving Landmarks are saved.")
+    ("fixed-landmarks", po::value<string>(&poParameters.strInputFixedLandmarksFileName), "Name of the file where the fixed Landmarks are saved.")
+    ("moving-landmarks", po::value<string>(&poParameters.strInputMovingLandmarksFileName), "Name of the file where the moving Landmarks are saved.")
     ("landmarks-variance,v", po::value<double>(&poParameters.dLandmarksVariance), "The variance that will be used to build the posterior model.")
     ;
 

--- a/modules/ITK/cli/statismo-fit-image.md
+++ b/modules/ITK/cli/statismo-fit-image.md
@@ -18,11 +18,11 @@ statismo-fit-image iteratively fits a target image with the help of a model and 
 -i, \--input-model *MODEL_FILE*
 :	*MODEL_FILE* is the path to the model.
 
--t, \--input-targetimage *IMAGE_FILE*
-:	*IMAGE_FILE* is the path to the target image.
+-m, \--input-movingimage *IMAGE_FILE*
+:	*IMAGE_FILE* is the path to the moving image.
 
--r, \--input-referenceimage *IMAGE_FILE*
-:	*IMAGE_FILE* is the path to the reference image.
+-f, \--input-fixedimage *IMAGE_FILE*
+:	*IMAGE_FILE* is the path to the fixed image.
 
 -w, \--regularization-weight *WEIGHT*
 :	*WEIGHT* is the regularization weight that is used to ensure that the model parameters don't deviate too much from the mean. The higher this weight is, the closer the model parameters should stay to the mean. Note: The regularization is the sum over the square of all model parameters.
@@ -42,10 +42,10 @@ statismo-fit-image iteratively fits a target image with the help of a model and 
 
 ## Landmarks (optional, if one is set then all have to be set)
 
--f, \--landmarks-fixed *FIXED_LANDMARKS_FILE*
+\--landmarks-fixed *FIXED_LANDMARKS_FILE*
 :	*FIXED_LANDMARKS_FILE* is the path to the the file containing the fixed landmarks.
 
--m, \--landmarks-moving *MOVING_LANDMARKS_FILE*
+\--landmarks-moving *MOVING_LANDMARKS_FILE*
 :	*MOVING_LANDMARKS_FILE* is the path to the the file containing the moving landmarks. (That's the landmarks on the target image)
 
 -v, \--landmarks-variance *VARIANCE*
@@ -75,20 +75,20 @@ Remark
 # Examples 
 Fit a 3D image without landmarks:
 
-    statismo-fit-image  -i model.h5 -w 0 -t target-image.vtk  -r reference-image.vtk -o projection.vtk
+    statismo-fit-image  -i model.h5 -w 0 -m moving-image.vtk  -f fixed-image.vtk -o projection.vtk
 
 
 Fit a 3D image with landmarks and print fitting information:
 
-    statismo-fit-image -i model.h5 -t target-image.vtk -w 0.1 -r reference-image.vtk -o projection.vtk -f fixed-landmarks.csv -m moving-landmarks-from-target-image.csv -v 0.1 -p
+    statismo-fit-image -i model.h5 -m moving-image.vtk -w 0.1 -f fixed-image.vtk -o projection.vtk --fixed-landmarks fixed-landmarks.csv --moving-landmarks moving-landmarks-from-target-image.csv -v 0.1 -p
 
 Fit a 2D image with landmarks and print fitting information:
 
-    statismo-fit-image -d 2 -i model.h5 -t target-image.vtk -w 0.25 -r reference-image.vtk -o projection.vtk -f fixed-landmarks.csv -m moving-landmarks-from-target-image.csv -v 0.1 -p
+    statismo-fit-image -d 2 -i model.h5 -m moving-image.vtk -w 0.25 -f fixed-image.vtk -o projection.vtk --fixed-landmarks fixed-landmarks.csv --moving-landmarks moving-landmarks-from-target-image.csv -v 0.1 -p
 
 Fit a 2D image without landmarks, print fitting information and save both the deformation field caused by the model and the entire deformation field:
 
-    statismo-fit-image -d 2 -i model.h5 -t target-image.vtk -w 0.25 -r reference-image.vtk -o projection.vtk -e model-deform-field.vtk -a entire-deform-field.vtk -p
+    statismo-fit-image -d 2 -i model.h5 -m moving-image.vtk -w 0.25 -f fixed-image.vtk -o projection.vtk -e model-deform-field.vtk -a entire-deform-field.vtk -p
 
 Hint
 :	Use *statismo-warp-image* to apply the deformation fields to images.

--- a/modules/ITK/cli/statismo-fit-image.md
+++ b/modules/ITK/cli/statismo-fit-image.md
@@ -42,10 +42,10 @@ statismo-fit-image iteratively fits a target image with the help of a model and 
 
 ## Landmarks (optional, if one is set then all have to be set)
 
-\--landmarks-fixed *FIXED_LANDMARKS_FILE*
+\--fixed-landmarks *FIXED_LANDMARKS_FILE*
 :	*FIXED_LANDMARKS_FILE* is the path to the the file containing the fixed landmarks.
 
-\--landmarks-moving *MOVING_LANDMARKS_FILE*
+\--moving-landmarks *MOVING_LANDMARKS_FILE*
 :	*MOVING_LANDMARKS_FILE* is the path to the the file containing the moving landmarks. (That's the landmarks on the target image)
 
 -v, \--landmarks-variance *VARIANCE*

--- a/modules/ITK/cli/test/CMakeLists.txt
+++ b/modules/ITK/cli/test/CMakeLists.txt
@@ -54,12 +54,12 @@ set_property( TEST statismo-sample-test-2d-image APPEND PROPERTY DEPENDS statism
 
 set( FILENAME_DEFORMATION_FIELD "${TEST_DEFORMATION_DATA_DIR}model-deform-field-no-landmarks.vtk" )
 add_test( NAME statismo-fit-image-test-2d-no-landmarks
-  COMMAND statismo-fit-image -d 2 -i "${FILENAME_GAUSSDEFORMATION_MODEL_2D}" -t "${STATISMO_DATA_DIR}/hand_images/hand-2.vtk" -w 0.25 -r "${STATISMO_DATA_DIR}/hand_images/hand-1.vtk" -o "${TEST_DEFORMATION_DATA_DIR}projection-hand2-no-landmarks.vtk" -e "${FILENAME_DEFORMATION_FIELD}" -a "${TEST_DEFORMATION_DATA_DIR}entire-deform-field-no-landmarks.vtk" -p
+  COMMAND statismo-fit-image -d 2 -i "${FILENAME_GAUSSDEFORMATION_MODEL_2D}" -m "${STATISMO_DATA_DIR}/hand_images/hand-2.vtk" -w 0.25 -f "${STATISMO_DATA_DIR}/hand_images/hand-1.vtk" -o "${TEST_DEFORMATION_DATA_DIR}projection-hand2-no-landmarks.vtk" -e "${FILENAME_DEFORMATION_FIELD}" -a "${TEST_DEFORMATION_DATA_DIR}entire-deform-field-no-landmarks.vtk" -p
   WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
 set_property( TEST statismo-fit-image-test-2d-no-landmarks APPEND PROPERTY DEPENDS statismo-build-gp-model-test-2d-image )
 
 add_test( NAME statismo-fit-image-test-2d-with-landmarks
-  COMMAND statismo-fit-image -d 2 -i "${FILENAME_GAUSSDEFORMATION_MODEL_2D}" -t "${STATISMO_DATA_DIR}/hand_images/hand-2.vtk" -w 0.25 -r "${STATISMO_DATA_DIR}/hand_images/hand-1.vtk" -o "${TEST_DEFORMATION_DATA_DIR}projection-hand2-with-landmarks.vtk" -f "${STATISMO_DATA_DIR}/hand_landmarks/hand-2.csv" -m "${STATISMO_DATA_DIR}/hand_landmarks/hand-1.csv" -v 0.1 -p
+  COMMAND statismo-fit-image -d 2 -i "${FILENAME_GAUSSDEFORMATION_MODEL_2D}" -m "${STATISMO_DATA_DIR}/hand_images/hand-2.vtk" -w 0.25 -f "${STATISMO_DATA_DIR}/hand_images/hand-1.vtk" -o "${TEST_DEFORMATION_DATA_DIR}projection-hand2-with-landmarks.vtk" --fixed-landmarks "${STATISMO_DATA_DIR}/hand_landmarks/hand-2.csv" --moving-landmarks "${STATISMO_DATA_DIR}/hand_landmarks/hand-1.csv" -v 0.1 -p
   WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
 set_property( TEST statismo-fit-image-test-2d-with-landmarks APPEND PROPERTY DEPENDS statismo-build-gp-model-test-2d-image )
 

--- a/modules/ITK/cli/test/CMakeLists.txt
+++ b/modules/ITK/cli/test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test( NAME statismo-build-gp-model-test-2d-image
   WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
 
 add_test( NAME statismo-build-gp-model-test-2d-image-extend-existing-model
-    COMMAND statismo-build-gp-model -d 2 -t deformation -k gaussian -p 75 -s 100 -n 100 -r "${STATISMO_DATA_DIR}hand_images/hand-1.vtk" -m "${FILENAME_GAUSSDEFORMATION_MODEL_2D}" "${TEST_DEFORMATION_DATA_DIR}2d extended gaussian deformationmodel.h5"
+    COMMAND statismo-build-gp-model -d 2 -t deformation -k gaussian -p 75 -s 100 -n 100 -m "${FILENAME_GAUSSDEFORMATION_MODEL_2D}" "${TEST_DEFORMATION_DATA_DIR}2d extended gaussian deformationmodel.h5"
     WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
 set_property( TEST statismo-build-gp-model-test-2d-image-extend-existing-model APPEND PROPERTY DEPENDS statismo-build-gp-model-test-2d-image )
 

--- a/modules/core/include/LowRankGPModelBuilder.h
+++ b/modules/core/include/LowRankGPModelBuilder.h
@@ -139,14 +139,7 @@ class LowRankGPModelBuilder: public ModelBuilder<T> {
         const MatrixValuedKernelType& kernel, unsigned numComponents,
         unsigned numPointsForNystrom = 500) const {
 
-        VectorType zeroVec = VectorType::Zero(
-                                 m_representer->GetDomain().GetNumberOfPoints()
-                                 * m_representer->GetDimensions());
-
-        typename RepresenterType::DatasetConstPointerType zeroMean =
-            m_representer->SampleVectorToSample(zeroVec);
-
-        return BuildNewModel(zeroMean, kernel, numComponents,
+        return BuildNewModel(m_representer->IdentitySample(), kernel, numComponents,
                              numPointsForNystrom);
     }
 

--- a/modules/core/include/Representer.h
+++ b/modules/core/include/Representer.h
@@ -280,6 +280,36 @@ class Representer {
     virtual void Save(const H5::Group& fg) const = 0;
 
     ///@}
+
+    /**
+     * \name Utiities
+     */
+    /*
+     * Returns a new dataset that corresponds to the zero element of the underlying vectorspace
+     * obtained when vectorizing a dataset.
+     *
+     */
+    virtual DatasetPointerType IdentitySample() const {
+
+        switch (this->GetType()) {
+            case POINT_SET:
+            case POLYGON_MESH:
+            case VOLUME_MESH: {
+                return CloneDataset(this->GetReference());
+                break;
+            }
+            case IMAGE:
+            case VECTOR: {
+                VectorType zeroVec = VectorType::Zero(GetDomain().GetNumberOfPoints() * GetDimensions());
+                return SampleVectorToSample(zeroVec);
+                break;
+            }
+            default: {
+                throw statismo::StatisticalModelException(
+                        "No cannonical identityDataset method is defined for custom Representers.");
+            }
+        }
+    }
 };
 
 }


### PR DESCRIPTION
Minor changes concerning the CLI interface, after having worked through the use cases described in the [wiki](https://github.com/statismo/statismo/wiki/statismo%20cli):

1. Renamed reference/target image to fixed/moving image in statismo-fit-image
2. Use model mean/reference in statismo-build-gp-model if a model is provided

@muefra Can you quickly check my modification and tell me if you agree with them or if you can spot any errors/inconsistencies?