### PR TITLE
Add command line option to specify number of iterations used in fitting

### DIFF
--- a/modules/ITK/cli/statismo-fit-image.cxx
+++ b/modules/ITK/cli/statismo-fit-image.cxx
@@ -77,6 +77,7 @@ struct programOptions {
     double dLandmarksVariance;
 
     unsigned uNumberOfDimensions;
+    unsigned uNumberOfIterations;
     double dRegularizationWeight;
 
     bool bPrintFittingInformation;
@@ -252,7 +253,7 @@ void fitImage(programOptions opt, ConsoleOutputSilencer* pCOSilencer) {
 
     typedef itk::LBFGSOptimizer OptimizerType;
     OptimizerType::Pointer pOptimizer = OptimizerType::New();
-    initializeOptimizer<OptimizerType>(pOptimizer, pModel->GetNumberOfPrincipalComponents(), pTransform->GetNumberOfParameters(), opt.bPrintFittingInformation, pCOSilencer);
+    initializeOptimizer<OptimizerType>(pOptimizer, opt.uNumberOfIterations, pModel->GetNumberOfPrincipalComponents(), pTransform->GetNumberOfParameters(), opt.bPrintFittingInformation, pCOSilencer);
 
     typedef itk::PenalizingMeanSquaresImageToImageMetric<ImageType, ImageType> MetricType;
     typename MetricType::Pointer pMetric = MetricType::New();
@@ -305,6 +306,7 @@ po::options_description initializeProgramOptions(programOptions& poParameters) {
     ("moving-image,m", po::value<string>(&poParameters.strInputMovingImageFileName), "The path to the moving image.")
     ("fixed-image,f", po::value<string>(&poParameters.strInputFixedImageFileName), "The path to the fixed image.")
     ("dimensionality,d", po::value<unsigned>(&poParameters.uNumberOfDimensions)->default_value(3), "Dimensionality of the input images & model")
+    ("number-of-iterations,n", po::value<unsigned>(&poParameters.uNumberOfIterations)->default_value(100), "Number of iterations")
     ("regularization-weight,w", po::value<double>(&poParameters.dRegularizationWeight), "This is the regularization weight to make sure the model parameters don't don't get too big while fitting.")
     ;
 

--- a/modules/ITK/cli/statismo-fit-image.md
+++ b/modules/ITK/cli/statismo-fit-image.md
@@ -27,6 +27,10 @@ statismo-fit-image iteratively fits a target image with the help of a model and 
 -w, \--regularization-weight *WEIGHT*
 :	*WEIGHT* is the regularization weight that is used to ensure that the model parameters don't deviate too much from the mean. The higher this weight is, the closer the model parameters should stay to the mean. Note: The regularization is the sum over the square of all model parameters.
 
+-n, \--number-of-iterations *NUM_ITERATIONS*
+:	the number of iterations used in the fitting process
+
+
 -d, \--dimensionality 
 :	Specifies the dimensionality of the images and the model (either 2 or 3).
 

--- a/modules/ITK/cli/statismo-fit-surface.cxx
+++ b/modules/ITK/cli/statismo-fit-surface.cxx
@@ -74,7 +74,7 @@ struct programOptions {
     string strOutputProjectedMeshFileName;
 
     double dRegularizationWeight;
-
+    unsigned uNumberOfIterations;
     string strInputFixedLandmarksFileName;
     string strInputMovingLandmarksFileName;
     double dLandmarksVariance;
@@ -264,7 +264,7 @@ void fitMesh(programOptions opt, ConsoleOutputSilencer* pCOSilencer) {
 
     typedef itk::LBFGSOptimizer OptimizerType;
     OptimizerType::Pointer pOptimizer = OptimizerType::New();
-    initializeOptimizer<OptimizerType>(pOptimizer, pModel->GetNumberOfPrincipalComponents(), pTransform->GetNumberOfParameters(), opt.bPrintFittingInformation, pCOSilencer);
+    initializeOptimizer<OptimizerType>(pOptimizer, opt.uNumberOfIterations, pModel->GetNumberOfPrincipalComponents(), pTransform->GetNumberOfParameters(), opt.bPrintFittingInformation, pCOSilencer);
 
     typedef itk::LinearInterpolateImageFunction<DistanceImageType, double> InterpolatorType;
     InterpolatorType::Pointer pInterpolator = InterpolatorType::New();
@@ -323,6 +323,7 @@ po::options_description initializeProgramOptions(programOptions& poParameters) {
 
     ("input-model,i", po::value<string>(&poParameters.strInputModelFileName), "The path to the model file.")
     ("input-targetmesh,t", po::value<string>(&poParameters.strInputTargetMeshFileName), "The path to the target mesh.")
+    ("number-of-iterations,n", po::value<unsigned>(&poParameters.uNumberOfIterations)->default_value(100), "Number of iterations")
     ("regularization-weight,w", po::value<double>(&poParameters.dRegularizationWeight), "This is the regularization weight to make sure the model parameters don't don't get too big while fitting.")
     ;
 

--- a/modules/ITK/cli/statismo-fit-surface.md
+++ b/modules/ITK/cli/statismo-fit-surface.md
@@ -29,6 +29,8 @@ statismo-fit-surface fits a model iteratively in to a target mesh and then saves
 
 -j, \--output-projected *PROJECTED_MESH_FILE*
 :	*PROJECTED_MESH_FILE* is the path where the projected mesh will be saved. At least one of the two output meshes has to be specified. It's also possible to save both.
+-n, \--number-of-iterations *NUM_ITERATIONS*
+:	the number of iterations used in the fitting process
 
 ## Landmarks (optional, if one is set then all have to be set)
 

--- a/modules/ITK/cli/utils/statismo-fitting-utils.h
+++ b/modules/ITK/cli/utils/statismo-fitting-utils.h
@@ -49,7 +49,7 @@ typename StatisticalModelType::Pointer buildPosteriorShapeModel(typename Statist
 template<class DataType, class StatisticalModelType>
 typename StatisticalModelType::Pointer buildPosteriorDeformationModel(typename StatisticalModelType::Pointer pModel, const std::string& strFixedLandmarksFileName, const std::string& strMovingLandmarksFileName, const double dLandmarksVariance);
 template<class OptimizerType>
-void initializeOptimizer(typename OptimizerType::Pointer pOptimizer, const unsigned uNumberOfModelComponents, const unsigned uTotalNumberOfOptimizationParameters, const bool bPrintFittingInformation, ConsoleOutputSilencer* pCOSilencer);
+void initializeOptimizer(typename OptimizerType::Pointer pOptimizer, const unsigned uNumberOfIterations, const unsigned uNumberOfModelComponents, const unsigned uTotalNumberOfOptimizationParameters, const bool bPrintFittingInformation, ConsoleOutputSilencer* pCOSilencer);
 
 #ifdef _WIN32
 #include <io.h>
@@ -173,8 +173,7 @@ class IterationStatusObserver : public itk::Command {
 
 
 template<class OptimizerType>
-void initializeOptimizer(typename OptimizerType::Pointer pOptimizer, const unsigned uNumberOfModelComponents, const unsigned uTotalNumberOfOptimizationParameters, const bool bPrintFittingInformation, ConsoleOutputSilencer* pCOSilencer) {
-    const unsigned uNumberOfIterations = 150;
+void initializeOptimizer(typename OptimizerType::Pointer pOptimizer, const unsigned uNumberOfIterations, const unsigned uNumberOfModelComponents, const unsigned uTotalNumberOfOptimizationParameters, const bool bPrintFittingInformation, ConsoleOutputSilencer* pCOSilencer) {
     const unsigned uNumberOfRigid2DtransformComponents = 3;
     const unsigned uNumberOfRigid3DtransformComponents = 6;
 


### PR DESCRIPTION
As it is currently difficult to define an automatic criterion when an optimization/fitting should stop, the user should be able to set the number of iterations manually.