### PR TITLE
Cli multiscale bspline

### DIFF
--- a/modules/ITK/cli/statismo-build-gp-model.md
+++ b/modules/ITK/cli/statismo-build-gp-model.md
@@ -74,12 +74,13 @@ Extend a 2D deformation model with a gaussian kernel and scale it up to 100 basi
 
     statismo-build-gp-model -d 2 -t deformation -k gaussian -p 75 -s 100 -n 100 -r reference-image.vtk -m input-model.h5 extended-model.h5
 
-<!-- 
-Build a shape model with a multi-parameter kernel and 50 basis functions: (this is an example on how to use multiple kernel parameters for future documentation writers)
 
-    statismo-build-gp-model -t shape -k multi-parameter[float,bool,int] -p 5.12 true -99 -s 100 -n 50 -r reference-mesh.vtk model.h5
+Build a shape model with a multiscale kernel using 50 basis functions. This is an example of a kernel that takes 2 parameters
+ (the support and number of levels)
+
+    statismo-build-gp-model -t shape -k multiscale -p 128 5 -s 100 -n 50 -r reference-mesh.vtk model.h5
 	
---> 
+
 
 # SEE ALSO
 

--- a/modules/ITK/cli/utils/statismo-build-gp-model-kernels.h
+++ b/modules/ITK/cli/utils/statismo-build-gp-model-kernels.h
@@ -156,15 +156,14 @@ public:
             throw statismo::StatisticalModelException(os.str().c_str());
         }
 
-        const double order = 3;
         const double supportBasisFunction = 4.0;
         const double scale = -1.0 * std::log(m_support / supportBasisFunction) / std::log(2);
 
         VectorType xScaled = x.GetVnlVector() * std::pow(2.0, scale);
         VectorType yScaled = y.GetVnlVector() * std::pow(2.0, scale);
 
-        VectorType kLower(dim);
-        VectorType kUpper(dim);
+        std::vector<int> kLower(dim);
+        std::vector<int> kUpper(dim);
         for (unsigned d = 0; d < dim; ++d) {
             kLower[d] = static_cast<int>(std::ceil(std::max(xScaled[d], yScaled[d]) - 0.5 * supportBasisFunction));
             kUpper[d] = static_cast<int>(std::floor(std::min(xScaled[d], yScaled[d]) + 0.5 * supportBasisFunction));
@@ -239,6 +238,7 @@ public:
         double support = supportBaseLevel;
         for (unsigned i = 0; i < numberOfLevels; ++i) {
             m_kernels.push_back(new BSplineKernel<TPoint>(m_supportBaseLevel * std::pow(2, -1.0 * i)));
+            m_kernelWeights.push_back(std::pow(2, -1.0 * i));
         }
     }
 
@@ -250,7 +250,7 @@ public:
         const unsigned dim = x.Size();
         double sum = 0;
         for (unsigned i = 0; i < m_kernels.size(); ++i) {
-            sum += m_kernels[i](x, y) * std::pow(2, -1.0 * i);
+            sum += m_kernels[i](x, y) * m_kernelWeights[i];
         }
 
         return sum;
@@ -266,6 +266,7 @@ private:
     double m_supportBaseLevel;
     unsigned m_numberOfLevels;
     boost::ptr_vector<BSplineKernel<TPoint> >  m_kernels;
+    std::vector<double> m_kernelWeights;
 };
 
 


### PR DESCRIPTION
Added two new kernels 

1. A B-Spline kernel
2. A Multiscale kernel that combines B-Spline kernels on different scale levels

Being able to define deformations on several scale levels is essential for accurate registration results. It should be included in the initial release of the CLI. 

The kernels should eventually be made available also in statismo core, such that users of the statismo library can access them directly. As this requires some refactoring of the structure of the kernels, it is postponed for later. 