### PR TITLE
Added vector double to PixelConversionTrait and RepresenterTraits

### DIFF
--- a/modules/ITK/include/itkPixelConversionTraits.h
+++ b/modules/ITK/include/itkPixelConversionTraits.h
@@ -279,6 +279,94 @@ template <> struct PixelConversionTrait<itk::Vector<float, 3> > {
     }
 };
 
+template <> struct PixelConversionTrait<itk::Vector<float, 4> > {
+    static statismo::VectorType ToVector(const itk::Vector<float, 4>& pixel) {
+        statismo::VectorType v(4);
+        v << pixel[0] , pixel[1], pixel[2], pixel[3];
+        return v;
+    }
+    static itk::Vector<float, 4> FromVector(const statismo::VectorType& v) {
+        assert(v.size() == 4);
+        itk::Vector<double, 4> itkVec;
+        itkVec[0] = v(0);
+        itkVec[1] = v(1);
+        itkVec[2] = v(2);
+		itkVec[3] = v(3);
+        return itkVec;
+    }
+    static  unsigned  GetDataType() {
+        return statismo::FLOAT;
+    }
+    static unsigned GetPixelDimension() {
+        return 4;
+    }
+};
+
+template <> struct PixelConversionTrait<itk::Vector<double, 2> > {
+    static statismo::VectorType ToVector(const itk::Vector<double, 2>& pixel) {
+        statismo::VectorType v(2);
+        v << pixel[0] , pixel[1];
+        return v;
+    }
+    static itk::Vector<double, 2> FromVector(const statismo::VectorType& v) {
+        assert(v.size() == 2);
+        itk::Vector<double, 2> itkVec;
+        itkVec[0] = v(0);
+        itkVec[1] = v(1);
+        return itkVec;
+    }
+    static  unsigned  GetDataType() {
+        return statismo::DOUBLE;
+    }
+    static unsigned GetPixelDimension() {
+        return 2;
+    }
+};
+
+template <> struct PixelConversionTrait<itk::Vector<double, 3> > {
+    static statismo::VectorType ToVector(const itk::Vector<double, 3>& pixel) {
+        statismo::VectorType v(3);
+        v << pixel[0] , pixel[1], pixel[2];
+        return v;
+    }
+    static itk::Vector<float, 3> FromVector(const statismo::VectorType& v) {
+        assert(v.size() == 3);
+        itk::Vector<double, 3> itkVec;
+        itkVec[0] = v(0);
+        itkVec[1] = v(1);
+        itkVec[2] = v(2);
+        return itkVec;
+    }
+    static  unsigned  GetDataType() {
+        return statismo::DOUBLE;
+    }
+    static unsigned GetPixelDimension() {
+        return 3;
+    }
+};
+
+template <> struct PixelConversionTrait<itk::Vector<double, 4> > {
+    static statismo::VectorType ToVector(const itk::Vector<double, 4>& pixel) {
+        statismo::VectorType v(4);
+        v << pixel[0] , pixel[1], pixel[2], pixel[3];
+        return v;
+    }
+    static itk::Vector<double, 4> FromVector(const statismo::VectorType& v) {
+        assert(v.size() == 4);
+        itk::Vector<double, 4> itkVec;
+        itkVec[0] = v(0);
+        itkVec[1] = v(1);
+        itkVec[2] = v(2);
+		itkVec[3] = v(3);
+        return itkVec;
+    }
+    static  unsigned  GetDataType() {
+		return statismo::DOUBLE;
+    }
+    static unsigned GetPixelDimension() {
+        return 4;
+    }
+};
 
 } // namespace itk
 

--- a/modules/ITK/include/itkPixelConversionTraits.h
+++ b/modules/ITK/include/itkPixelConversionTraits.h
@@ -291,7 +291,7 @@ template <> struct PixelConversionTrait<itk::Vector<float, 4> > {
         itkVec[0] = v(0);
         itkVec[1] = v(1);
         itkVec[2] = v(2);
-		itkVec[3] = v(3);
+        itkVec[3] = v(3);
         return itkVec;
     }
     static  unsigned  GetDataType() {
@@ -357,11 +357,11 @@ template <> struct PixelConversionTrait<itk::Vector<double, 4> > {
         itkVec[0] = v(0);
         itkVec[1] = v(1);
         itkVec[2] = v(2);
-		itkVec[3] = v(3);
+        itkVec[3] = v(3);
         return itkVec;
     }
     static  unsigned  GetDataType() {
-		return statismo::DOUBLE;
+        return statismo::DOUBLE;
     }
     static unsigned GetPixelDimension() {
         return 4;

--- a/modules/ITK/include/itkStandardImageRepresenterTraits.h
+++ b/modules/ITK/include/itkStandardImageRepresenterTraits.h
@@ -44,7 +44,7 @@
 
 namespace statismo {
 
-	template<>
+template<>
 struct RepresenterTraits<itk::Image<itk::Vector<double, 4u>, 4u> > {
 
     typedef itk::Image<itk::Vector<double, 4u>, 4u> VectorImageType;
@@ -65,7 +65,7 @@ struct RepresenterTraits<itk::Image<itk::Vector<double, 3u>, 3u> > {
 };
 
 template<>
-struct RepresenterTraits<itk::Image<itk::Vector<double, 2>, 2> > {
+struct RepresenterTraits<itk::Image<itk::Vector<double, 2u>, 2u> > {
 
     typedef itk::Image<itk::Vector<double, 2u>, 2u> VectorImageType;
     typedef VectorImageType::Pointer DatasetPointerType;

--- a/modules/ITK/include/itkStandardImageRepresenterTraits.h
+++ b/modules/ITK/include/itkStandardImageRepresenterTraits.h
@@ -44,6 +44,38 @@
 
 namespace statismo {
 
+	template<>
+struct RepresenterTraits<itk::Image<itk::Vector<double, 4u>, 4u> > {
+
+    typedef itk::Image<itk::Vector<double, 4u>, 4u> VectorImageType;
+    typedef VectorImageType::Pointer DatasetPointerType;
+    typedef VectorImageType::Pointer DatasetConstPointerType;
+    typedef VectorImageType::PointType PointType;
+    typedef VectorImageType::PixelType ValueType;
+};
+
+template<>
+struct RepresenterTraits<itk::Image<itk::Vector<double, 3u>, 3u> > {
+
+    typedef itk::Image<itk::Vector<double, 3u>, 3u> VectorImageType;
+    typedef VectorImageType::Pointer DatasetPointerType;
+    typedef VectorImageType::Pointer DatasetConstPointerType;
+    typedef VectorImageType::PointType PointType;
+    typedef VectorImageType::PixelType ValueType;
+};
+
+template<>
+struct RepresenterTraits<itk::Image<itk::Vector<double, 2>, 2> > {
+
+    typedef itk::Image<itk::Vector<double, 2u>, 2u> VectorImageType;
+    typedef VectorImageType::Pointer DatasetPointerType;
+    typedef VectorImageType::Pointer DatasetConstPointerType;
+    typedef VectorImageType::PointType PointType;
+    typedef VectorImageType::PixelType ValueType;
+};
+
+
+
 template<>
 struct RepresenterTraits<itk::Image<itk::Vector<float, 4u>, 4u> > {
 


### PR DESCRIPTION
Hi, I was working with statismo-elastix and i was getting errors using an vector image of type double, so now I added it (thanks also to Arnaud)