### PR TITLE
Example for removing boost::bind from ITK wrapping.

### DIFF
--- a/modules/ITK/include/itkPosteriorModelBuilder.h
+++ b/modules/ITK/include/itkPosteriorModelBuilder.h
@@ -40,12 +40,8 @@
 #define ITK_POSTERIOR_MODELBUILDER_H_
 
 #include <itkObject.h>
-
-#include "itkDataManager.h"
 #include "itkStatisticalModel.h"
-
 #include "PosteriorModelBuilder.h"
-#include "statismoITKConfig.h"
 
 namespace itk {
 
@@ -69,18 +65,6 @@ class PosteriorModelBuilder : public Object {
     typedef statismo::DataManager<T> DataManagerType;
     typedef typename DataManagerType::DataItemListType DataItemListType;
 
-
-
-    template <class F>
-    typename boost::result_of<F()>::type callstatismoImpl(F f) const {
-        try {
-            return f();
-        } catch (statismo::StatisticalModelException& s) {
-            itkExceptionMacro(<< s.what());
-        }
-    }
-
-
     PosteriorModelBuilder() : m_impl(ImplType::Create()) {}
 
     virtual ~PosteriorModelBuilder() {
@@ -89,8 +73,7 @@ class PosteriorModelBuilder : public Object {
             m_impl = 0;
         }
     }
-
-
+    
     // create statismo stuff
     typedef  statismo::Representer<T> RepresenterType;
     typedef  typename RepresenterType::ValueType ValueType;
@@ -102,37 +85,50 @@ class PosteriorModelBuilder : public Object {
     typedef statismo::StatisticalModel<T> StatismoStatisticalModelType;
 
     typename StatisticalModelType::Pointer BuildNewModelFromModel(const StatisticalModelType* model, const PointValueListType& pointValues, double pointValuesNoiseVariance,  bool computeScores=true) {
+      try {
         StatismoStatisticalModelType* model_statismo = model->GetstatismoImplObj();
-        StatismoStatisticalModelType* new_model_statismo = callstatismoImpl(boost::bind(
-                    static_cast<StatismoStatisticalModelType* (ImplType::*) (const StatismoStatisticalModelType* model, const PointValueListType& pointValues, double pointValuesNoiseVariance,  bool computeScores) const > (&ImplType::BuildNewModelFromModel),
-                    this->m_impl, model_statismo, pointValues, pointValuesNoiseVariance, computeScores));
+        StatismoStatisticalModelType* new_model_statismo = this->m_impl->BuildNewModelFromModel(model_statismo, pointValues, pointValuesNoiseVariance, computeScores);
         typename StatisticalModelType::Pointer model_itk = StatisticalModelType::New();
         model_itk->SetstatismoImplObj(new_model_statismo);
         return model_itk;
+      } catch (statismo::StatisticalModelException& s) {
+        itkExceptionMacro(<< s.what());
+      }
     }
 
     typename StatisticalModelType::Pointer BuildNewModel(DataItemListType DataItemList, const PointValueListType& pointValues, double pointValuesNoiseVariance, double noiseVariance) {
-        StatismoStatisticalModelType* model_statismo = callstatismoImpl(boost::bind(&ImplType::BuildNewModel, this->m_impl, DataItemList ,pointValues, pointValuesNoiseVariance, noiseVariance));
+      try {
+        StatismoStatisticalModelType* model_statismo = this->m_impl->BuildNewModel(DataItemList, pointValues, pointValuesNoiseVariance, noiseVariance);
         typename StatisticalModelType::Pointer model_itk = StatisticalModelType::New();
         model_itk->SetstatismoImplObj(model_statismo);
         return model_itk;
+      } catch (statismo::StatisticalModelException& s) {
+        itkExceptionMacro(<< s.what());
+      }
     }
 
     typename StatisticalModelType::Pointer BuildNewModelFromModel(const StatisticalModelType* model, const PointValueWithCovarianceListType& pointValuesWithCovariance,  bool computeScores=true) {
+      try {
         StatismoStatisticalModelType* model_statismo = model->GetstatismoImplObj();
-        StatismoStatisticalModelType* new_model_statismo = callstatismoImpl(boost::bind(
-                    static_cast<StatismoStatisticalModelType* (ImplType::*) (const StatismoStatisticalModelType* model, const PointValueWithCovarianceListType& pointValuesWithCovariance,  bool computeScores) const > (&ImplType::BuildNewModelFromModel),
-                    this->m_impl, model_statismo, pointValuesWithCovariance, computeScores));
+        StatismoStatisticalModelType* new_model_statismo = this->m_impl->BuildNewModelFromModel(this->m_impl, model_statismo, pointValuesWithCovariance, computeScores);
         typename StatisticalModelType::Pointer model_itk = StatisticalModelType::New();
         model_itk->SetstatismoImplObj(new_model_statismo);
         return model_itk;
+      } catch (statismo::StatisticalModelException& s) {
+        itkExceptionMacro(<< s.what());
+      }
     }
 
     typename StatisticalModelType::Pointer BuildNewModel(const DataItemListType& DataItemList, const PointValueWithCovarianceListType& pointValuesWithCovariance, 	double noiseVariance) {
-        StatismoStatisticalModelType* model_statismo = callstatismoImpl(boost::bind(&ImplType::BuildNewModel, this->m_impl, DataItemList, pointValuesWithCovariance, noiseVariance));
+      try {
+        StatismoStatisticalModelType* model_statismo = this->m_impl->BuildNewModel(this->m_impl, DataItemList, pointValuesWithCovariance, noiseVariance);
         typename StatisticalModelType::Pointer model_itk = StatisticalModelType::New();
         model_itk->SetstatismoImplObj(model_statismo);
         return model_itk;
+      }
+      catch (statismo::StatisticalModelException& s) {
+        itkExceptionMacro(<< s.what());
+      }
     }
 
   private:

--- a/modules/ITK/include/itkPosteriorModelBuilder.h
+++ b/modules/ITK/include/itkPosteriorModelBuilder.h
@@ -110,7 +110,7 @@ class PosteriorModelBuilder : public Object {
     typename StatisticalModelType::Pointer BuildNewModelFromModel(const StatisticalModelType* model, const PointValueWithCovarianceListType& pointValuesWithCovariance,  bool computeScores=true) {
       try {
         StatismoStatisticalModelType* model_statismo = model->GetstatismoImplObj();
-        StatismoStatisticalModelType* new_model_statismo = this->m_impl->BuildNewModelFromModel(this->m_impl, model_statismo, pointValuesWithCovariance, computeScores);
+        StatismoStatisticalModelType* new_model_statismo = this->m_impl->BuildNewModelFromModel(model_statismo, pointValuesWithCovariance, computeScores);
         typename StatisticalModelType::Pointer model_itk = StatisticalModelType::New();
         model_itk->SetstatismoImplObj(new_model_statismo);
         return model_itk;
@@ -121,7 +121,7 @@ class PosteriorModelBuilder : public Object {
 
     typename StatisticalModelType::Pointer BuildNewModel(const DataItemListType& DataItemList, const PointValueWithCovarianceListType& pointValuesWithCovariance, 	double noiseVariance) {
       try {
-        StatismoStatisticalModelType* model_statismo = this->m_impl->BuildNewModel(this->m_impl, DataItemList, pointValuesWithCovariance, noiseVariance);
+        StatismoStatisticalModelType* model_statismo = this->m_impl->BuildNewModel(DataItemList, pointValuesWithCovariance, noiseVariance);
         typename StatisticalModelType::Pointer model_itk = StatisticalModelType::New();
         model_itk->SetstatismoImplObj(model_statismo);
         return model_itk;


### PR DESCRIPTION
This is mainly to start a discussion. I think the use of ```boost::bind``` in the ITK wrapping is over-complicated and really unpleasant to debug. 

Its only use is to evade writing a try/catch block in every method. But I think the try/catch block is easier to read, understand, debug, and maintain than the binding in every function. This way actually duplicates less code than the boost::bind implementation. (Check for instance the number of characters in lines 106-108 below).

If we ever find ourselves in the position to do more than ```itkExceptionMacro(<< s.what());``` in the catch block, we could easily replace the ```itkExceptionMacro``` with a different macro. Of course, a macro is old-school and not functional programming, but in the current solution we use a bunch of functional programming to reduce every function to a function of void to then call a macro...

Of course this is only one file, and this would need to be done in every file for the ITK wrapping. I hope somebody is willing to help.