### PR TITLE
Make it easier to run tests on windows:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,13 @@ option( BUILD_EXAMPLES "Build examples" ON )
 option( BUILD_WRAPPING "Build Python Wrappers (experimental)" OFF )
 mark_as_advanced(BUILD_WRAPPING)
 
+#make sure the executables have access to the dll's created by the superbuild on windows to make them runnable even without installing & adding the isntall path to the cmd PATH
+if( NOT INSTALL_DEPENDENCIES_DIR )
+  set( TESTS_WORKING_DIR "." CACHE INTERNAL "")
+else()
+  set( TEST_WORKING_DIR "${INSTALL_DEPENDENCIES_DIR}/bin" CACHE INTERNAL "")
+endif()
+
 add_subdirectory( modules )
 add_subdirectory( doc )
 # -------------------------------------------------------------

--- a/modules/ITK/cli/test/CMakeLists.txt
+++ b/modules/ITK/cli/test/CMakeLists.txt
@@ -4,12 +4,6 @@
 set( TEST_DEFORMATION_DATA_DIR "${CMAKE_BINARY_DIR}/tests-cli/deformation/" )
 set( TEST_SHAPE_DATA_DIR "${CMAKE_BINARY_DIR}/tests-cli/shape/" )
 set( STATISMO_DATA_DIR "${statismo_SOURCE_DIR}/data/" )
-#make sure the executables have access to the dll's created by the superbuild on windows
-if( NOT INSTALL_DEPENDENCIES_DIR )
-  set( TEST_WORKING_DIR "." )
-else()
-  set( TEST_WORKING_DIR "${INSTALL_DEPENDENCIES_DIR}/bin" )
-endif()
 
 #write a file containing the paths to the deformation fields/meshes to build the models.
 #in this test the absolute paths are used so that it's independent from the current working directory. Paths relative to the current working directory can be used as well.

--- a/modules/ITK/tests/CMakeLists.txt
+++ b/modules/ITK/tests/CMakeLists.txt
@@ -10,8 +10,9 @@ endforeach()
 
 add_test( NAME itkStandardImageRepresenterTest
   COMMAND itkStandardImageRepresenterTest ${statismo_SOURCE_DIR}/data
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
+
 add_test( NAME itkStandardMeshRepresenterTest
   COMMAND itkStandardMeshRepresenterTest ${statismo_SOURCE_DIR}/data
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
 

--- a/modules/VTK/tests/CMakeLists.txt
+++ b/modules/VTK/tests/CMakeLists.txt
@@ -12,13 +12,16 @@ endforeach()
 
 add_test( NAME PosteriorModelBuilderTest
   COMMAND PosteriorModelBuilderTest ${statismo_SOURCE_DIR}/data
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
+
 add_test( NAME PCAModelBuilderWithSelfAdjointEigenSolverTest
   COMMAND PCAModelBuilderWithSelfAdjointEigenSolverTest ${statismo_SOURCE_DIR}/data
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
+
 add_test( NAME vtkStandardImageRepresenterTest
   COMMAND vtkStandardImageRepresenterTest ${statismo_SOURCE_DIR}/data
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )
+
 add_test( NAME vtkStandardMeshRepresenterTest
   COMMAND vtkStandardMeshRepresenterTest ${statismo_SOURCE_DIR}/data
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )

--- a/modules/core/tests/CMakeLists.txt
+++ b/modules/core/tests/CMakeLists.txt
@@ -9,4 +9,4 @@ endforeach()
 
 add_test( NAME basicStatismoTest
   COMMAND basicStatismoTest
-)
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}" )


### PR DESCRIPTION
I am not sure whether there's any interest in this, but with a few small changes it's possible to make running the tests on windows a tad easier.

    [compile using the superbuild]
    cd build/Statismo-build
    ctest

Since the working-directory is set to the path where all the built dependencies reside, the tests are able to find the dlls they require to be run.