### PR TITLE
Removed the Dataset/Sample distinction [There was no automatic alignment anyways]

### DIFF
--- a/doc/IJ/pictures/class_diagram.svg
+++ b/doc/IJ/pictures/class_diagram.svg
@@ -427,21 +427,21 @@ font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal"
 font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal" 
 >
 <text fill="#000000" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="353" font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal" 
- >ComputeProbabilityOfDataset()</text>
+ >ComputeProbability()</text>
 </g>
 
 <g fill="#ffffc0" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,-179,-157)"
 font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal" 
 >
 <text fill="#000000" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="369" font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal" 
- >ComputeLogProbabilityOfDataset()</text>
+ >ComputeLogProbability()</text>
 </g>
 
 <g fill="#ffffc0" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,-179,-157)"
 font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal" 
 >
 <text fill="#000000" fill-opacity="1" stroke="none" xml:space="preserve" x="807" y="385" font-family="Sans Serif" font-size="10" font-weight="400" font-style="normal" 
- >ComputeCoefficientsForDataset()</text>
+ >ComputeCoefficients()</text>
 </g>
 
 <g fill="#ffffc0" fill-opacity="1" stroke="#000000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,-179,-157)"

--- a/doc/IJ/statismo_ij.tex
+++ b/doc/IJ/statismo_ij.tex
@@ -411,10 +411,8 @@ discretized, normalized and converted into a consistent vectorial
 form.  The discretization and normalization step are specific to the
 type of object that are modeled.  A \code{Representer} class in
 \Statismo needs to provide the methods
-\code{Representer::DatasetToSample},
 \code{Representer::SampleToSampleVector} and
-\code{Representer::SampleVectorToSample}.  The first method takes care
-of the discretization and normalization, the second method is used to
+\code{Representer::SampleVectorToSample}.  The first method is used to
 convert a dataset to its vectorial representation.  The last method is
 used to convert the vectorial representation back to an object of the
 modeled type. Figure~\ref{fig:statismo-flow} illustrates this concept.
@@ -594,13 +592,13 @@ obtained by computing the PCA coefficients for a given dataset and then restorin
 \code{DrawSample} method:
 \begin{verbatim}
 vtkPolyData* dataset = someAlgorithm();
-VectorType coeffs = model->ComputeCoefficientsForDataset(dataset);
+VectorType coeffs = model->ComputeCoefficients(dataset);
 vtkPolyData* projection = model->DrawSample(coeffs);
 \end{verbatim}
 Often, an algorithm is regularized by penalizing unlikely solutions. For this purpose, \Statismo 
 provides a method to compute a (log) probability of a given dataset. 
 \begin{verbatim}
-float logProbability = model->ComputeLogProbabilityForDataset(aDataset);
+float logProbability = model->ComputeLogProbability(aDataset);
 \end{verbatim}
 
 \subsection{Cross validation}
@@ -635,7 +633,7 @@ for (CVFoldListType::const_iterator it = cvFoldList.begin();
     {
         vtkPolyData* testSample = (*it)->GetAsNewSample();
         vtkPolyData* projection = model->DrawSample(
-                                         model->ComputeCoefficientsForDataset(dataset));
+                                         model->ComputeCoefficients(dataset));
         /// here we could for example compute the approximation error between the 
         /// projection and the test sample - omitted
 

--- a/modules/ITK/include/itkStandardImageRepresenter.h
+++ b/modules/ITK/include/itkStandardImageRepresenter.h
@@ -126,7 +126,6 @@ class StandardImageRepresenter: public Object, public statismo::Representer<
      * Alignment.
      */
     statismo::VectorType PointToVector(const PointType& pt) const;
-    DatasetPointerType DatasetToSample(DatasetConstPointerType ds) const;
     statismo::VectorType SampleToSampleVector(DatasetConstPointerType sample) const;
     DatasetPointerType SampleVectorToSample(
         const statismo::VectorType& sample) const;

--- a/modules/ITK/include/itkStandardImageRepresenter.hxx
+++ b/modules/ITK/include/itkStandardImageRepresenter.hxx
@@ -232,17 +232,6 @@ StandardImageRepresenter<TPixel, ImageDimension>::PointToVector(const PointType&
 
 
 
-template <class TPixel, unsigned ImageDimension>
-typename StandardImageRepresenter<TPixel, ImageDimension>::DatasetPointerType
-StandardImageRepresenter<TPixel, ImageDimension>::DatasetToSample(DatasetConstPointerType image) const {
-    // we don't do any alignment for images, but simply return a copy of the image
-
-    typename itk::ImageDuplicator<ImageType>::Pointer duplicator = itk::ImageDuplicator<ImageType>::New();
-    duplicator->SetInputImage(image);
-    duplicator->Update();
-    return duplicator->GetOutput();
-
-}
 
 template <class TPixel, unsigned ImageDimension>
 statismo::VectorType

--- a/modules/ITK/include/itkStandardMeshRepresenter.h
+++ b/modules/ITK/include/itkStandardMeshRepresenter.h
@@ -153,11 +153,6 @@ class StandardMeshRepresenter : public statismo::Representer<itk::Mesh<TPixel, M
 
 
     /**
-     * Create a sample from the dataset. No alignment or registration is done
-     */
-    DatasetPointerType DatasetToSample(DatasetConstPointerType ds) const;
-
-    /**
      * Converts a sample to its vectorial representation
      */
     statismo::VectorType SampleToSampleVector(DatasetConstPointerType sample) const;

--- a/modules/ITK/include/itkStandardMeshRepresenter.hxx
+++ b/modules/ITK/include/itkStandardMeshRepresenter.hxx
@@ -227,13 +227,6 @@ StandardMeshRepresenter<TPixel, MeshDimension>::PointToVector(const PointType& p
 }
 
 template <class TPixel, unsigned MeshDimension>
-typename StandardMeshRepresenter<TPixel, MeshDimension>::DatasetPointerType
-StandardMeshRepresenter<TPixel, MeshDimension>::DatasetToSample(DatasetConstPointerType ds) const {
-    // we don't do any alignment, but simply return a clone of the dataset
-    return this->CloneDataset(ds);
-}
-
-template <class TPixel, unsigned MeshDimension>
 statismo::VectorType
 StandardMeshRepresenter<TPixel, MeshDimension>::SampleToSampleVector(DatasetConstPointerType mesh) const {
     statismo::VectorType sample(GetNumberOfPoints() * GetDimensions());

--- a/modules/ITK/include/itkStatisticalModel.h
+++ b/modules/ITK/include/itkStatisticalModel.h
@@ -193,24 +193,16 @@ class StatisticalModel : public Object {
     }
 
 
-    VectorType ComputeCoefficientsForDataset(DatasetConstPointerType ds) const {
-        return toVnlVector(callstatismoImpl(boost::bind(&ImplType::ComputeCoefficientsForDataset, this->m_impl, ds)));
+    VectorType ComputeCoefficients(DatasetConstPointerType ds) const {
+        return toVnlVector(callstatismoImpl(boost::bind(&ImplType::ComputeCoefficients, this->m_impl, ds)));
     }
 
-    VectorType ComputeCoefficientsForSample(DatasetConstPointerType ds) const {
-        return toVnlVector(callstatismoImpl(boost::bind(&ImplType::ComputeCoefficientsForSample, this->m_impl, ds)));
+    double ComputeLogProbability(DatasetConstPointerType ds) const {
+        return callstatismoImpl(boost::bind(&ImplType::ComputeLogProbability, this->m_impl, ds));
     }
 
-    VectorType ComputeCoefficientsForDataSample(const DataItemType* sample) const {
-        return toVnlVector(callstatismoImpl(boost::bind(&ImplType::ComputeCoefficientsForDataSample, this->m_impl, sample)));
-    }
-
-    double ComputeLogProbabilityOfDataset(DatasetConstPointerType ds) const {
-        return callstatismoImpl(boost::bind(&ImplType::ComputeLogProbabilityOfDataset, this->m_impl, ds));
-    }
-
-    double ComputeProbabilityOfDataset(DatasetConstPointerType ds) const {
-        return callstatismoImpl(boost::bind(&ImplType::ComputeProbabilityOfDataset, this->m_impl, ds));
+    double ComputeProbability(DatasetConstPointerType ds) const {
+        return callstatismoImpl(boost::bind(&ImplType::ComputeProbability, this->m_impl, ds));
     }
 
     double ComputeLogProbabilityOfCoefficients(const VectorType& coeffs) const {
@@ -221,8 +213,8 @@ class StatisticalModel : public Object {
         return callstatismoImpl(boost::bind(&ImplType::ComputeProbabilityOfCoefficients, this->m_impl, fromVnlVector(coeffs)));
     }
 
-    double ComputeMahalanobisDistanceForDataset(DatasetConstPointerType ds) const {
-        return callstatismoImpl(boost::bind(&ImplType::ComputeMahalanobisDistanceForDataset, this->m_impl, ds));
+    double ComputeMahalanobisDistance(DatasetConstPointerType ds) const {
+        return callstatismoImpl(boost::bind(&ImplType::ComputeMahalanobisDistance, this->m_impl, ds));
     }
 
     VectorType ComputeCoefficientsForPointValues(const PointValueListType& pvlist, double variance) const {
@@ -233,10 +225,6 @@ class StatisticalModel : public Object {
     VectorType ComputeCoefficientsForPointValuesWithCovariance(const PointValueWithCovarianceListType& pvclist) const {
       typedef statismo::VectorType(ImplType::*functype)(const PointValueWithCovarianceListType&) const;
       return toVnlVector(callstatismoImpl(boost::bind(static_cast<functype>(&ImplType::ComputeCoefficientsForPointValuesWithCovariance), this->m_impl, pvclist)));
-    }
-
-    DatasetPointerType DatasetToSample(DatasetConstPointerType ds) const {
-        return callstatismoImpl(boost::bind(&ImplType::DatasetToSample, this->m_impl, ds));
     }
 
     unsigned GetNumberOfPrincipalComponents() const {

--- a/modules/VTK/examples/vtkCrossValidationExample.cxx
+++ b/modules/VTK/examples/vtkCrossValidationExample.cxx
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
                     it != testSamplesList.end();
                     ++it) {
                 vtkPolyData* testSample = (*it)->GetSample();
-                std::cout << "probability of test sample under the model: " << model->ComputeProbabilityOfDataset(testSample) << std::endl;
+                std::cout << "probability of test sample under the model: " << model->ComputeProbability(testSample) << std::endl;
 
                 // We are responsible for deleting the sample.
                 testSample->Delete();

--- a/modules/VTK/include/vtkStandardImageRepresenter.h
+++ b/modules/VTK/include/vtkStandardImageRepresenter.h
@@ -130,7 +130,6 @@ class vtkStandardImageRepresenter  : public Representer<vtkStructuredPoints> {
     }
 
     statismo::VectorType PointToVector(const PointType& pt) const;
-    DatasetPointerType DatasetToSample(DatasetConstPointerType ds) const;
     statismo::VectorType SampleToSampleVector(DatasetConstPointerType sample) const;
     DatasetPointerType SampleVectorToSample(const statismo::VectorType& sample) const;
 

--- a/modules/VTK/include/vtkStandardImageRepresenter.hxx
+++ b/modules/VTK/include/vtkStandardImageRepresenter.hxx
@@ -291,23 +291,6 @@ statismo::VectorType vtkStandardImageRepresenter<TScalar, PixelDimensions>::Poin
 }
 
 template<class TScalar, unsigned PixelDimensions>
-typename vtkStandardImageRepresenter<TScalar, PixelDimensions>::DatasetPointerType vtkStandardImageRepresenter<
-TScalar, PixelDimensions>::DatasetToSample(
-    DatasetConstPointerType dataset) const {
-    // for this representer, a dataset is always the same as a sample
-    vtkStructuredPoints* clone = vtkStructuredPoints::New();
-    clone->DeepCopy(const_cast<vtkStructuredPoints*>(dataset));
-
-    if (const_cast<vtkStructuredPoints*>(m_reference)->GetNumberOfPoints()
-            != const_cast<vtkStructuredPoints*>(dataset)->GetNumberOfPoints()) {
-        throw StatisticalModelException(
-            "The dataset need to have the same number of points as the reference");
-    }
-
-    return clone;
-}
-
-template<class TScalar, unsigned PixelDimensions>
 VectorType vtkStandardImageRepresenter<TScalar, PixelDimensions>::SampleToSampleVector(
     DatasetConstPointerType _sp) const {
 

--- a/modules/VTK/tests/PosteriorModelBuilderTest.cxx
+++ b/modules/VTK/tests/PosteriorModelBuilderTest.cxx
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
 
     vtkPolyData* posteriorMean = anisotropicPosteriorModel->DrawMean();
 
-    double probability = fullModel->ComputeLogProbabilityOfDataset(posteriorMean);
+    double probability = fullModel->ComputeLogProbability(posteriorMean);
 
     //writePolyData(posteriorMean,"/local/tmp/hand-test.vtk");
     //fullModel->Save("/local/tmp/hand-model.h5");
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
 
     
     VectorType coeffs = fullModel->ComputeCoefficientsForPointValuesWithCovariance(pointValueWithCovarianceList);
-    VectorType coeffsFromPosteriorMean = fullModel->ComputeCoefficientsForDataset(posteriorMean);
+    VectorType coeffsFromPosteriorMean = fullModel->ComputeCoefficients(posteriorMean);
     VectorType difference = coeffs - coeffsFromPosteriorMean;
     double norm_difference = difference.norm();
     if(norm_difference > tolerance)

--- a/modules/VTK/wrapping/statismo.i
+++ b/modules/VTK/wrapping/statismo.i
@@ -331,7 +331,6 @@ public:
 
 
 	 ValueType EvaluateSampleAtPoint(DatasetConstPointerType sample, const PointType& point) const;
-	 DatasetPointerType DatasetToSample(DatasetConstPointerType ds) const;
 	 DatasetPointerType DrawMean() const;	
 	 ValueType DrawMeanAtPoint(const PointType& pt) const;
 	 %rename("DrawMeanAtPointId") DrawMeanAtPoint(unsigned) const;
@@ -347,15 +346,14 @@ public:
        DatasetPointerType DrawPCABasisSample(unsigned componentNumber) const;
 
 	 
-	 statismo::VectorType ComputeCoefficientsForDataset(DatasetConstPointerType ds) const;
-     statismo::VectorType ComputeCoefficientsForSample(DatasetConstPointerType ds) const;
+	 statismo::VectorType ComputeCoefficients(DatasetConstPointerType ds) const;
      statismo::VectorType ComputeCoefficientsForSampleVector(const statismo::VectorType& sample) const;
 	 statismo::VectorType ComputeCoefficientsForPointValues(const PointValueListType&  pointValues) const;
 	 statismo::VectorType ComputeCoefficientsForPointIDValues(const PointIdValueListType&  pointValues) const;
 
-	 double ComputeLogProbabilityOfDataset(DatasetConstPointerType ds) const;
-	 double ComputeProbabilityOfDataset(DatasetConstPointerType ds) const;
-         double ComputeMahalanobisDistanceForDataset(DatasetConstPointerType ds) const;
+	 double ComputeLogProbability(DatasetConstPointerType ds) const;
+	 double ComputeProbability(DatasetConstPointerType ds) const;
+         double ComputeMahalanobisDistance(DatasetConstPointerType ds) const;
 
 	 statismo::MatrixType GetCovarianceAtPoint(const PointType& pt1, const PointType& pt2) const;
 	 statismo::MatrixType GetCovarianceAtPoint(unsigned ptId1, unsigned ptId2) const;

--- a/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
         samples = self.dataManager.GetData()
         sample = samples[0].GetSample()
         print sample.GetNumberOfPoints()
-        coeffs_sample = model.ComputeCoefficientsForDataset(sample)
+        coeffs_sample = model.ComputeCoefficients(sample)
         restored_sample = model.DrawSample(coeffs_sample)
  
         self.assertEqual(sample.GetNumberOfPoints(), restored_sample.GetNumberOfPoints())
@@ -180,8 +180,8 @@ class Test(unittest.TestCase):
         pca_model = pcamodelbuilder.BuildNewModel(self.dataManager.GetData(), 0.1)
         
         sample  =  self.dataManager.GetData()[0].GetSample()
-        coeffs_pf_model = pf_model.ComputeCoefficientsForDataset(sample)
-        coeffs_pca_model =   pca_model.ComputeCoefficientsForDataset(sample)
+        coeffs_pf_model = pf_model.ComputeCoefficients(sample)
+        coeffs_pca_model =   pca_model.ComputeCoefficients(sample)
         for i in xrange(0, len(coeffs_pf_model)):
             # the sign is allowed to change
             self.assertAlmostEqual(abs(coeffs_pf_model[i]), abs(coeffs_pca_model[i]), 1)
@@ -280,8 +280,8 @@ class Test(unittest.TestCase):
         pca_model = pcamodelbuilder.BuildNewModel(self.dataManager.GetData(), 0.1)
         
         sample  =  self.dataManager.GetData()[0].GetSample()
-        coeffs_pf_model = pf_model.ComputeCoefficientsForDataset(sample)
-        coeffs_pca_model =   pca_model.ComputeCoefficientsForDataset(sample)
+        coeffs_pf_model = pf_model.ComputeCoefficients(sample)
+        coeffs_pca_model =   pca_model.ComputeCoefficients(sample)
         for i in xrange(0, len(coeffs_pf_model)):
             # the sign is allowed to change
             self.assertAlmostEqual(abs(coeffs_pf_model[i]), abs(coeffs_pca_model[i]), 1)

--- a/modules/VTK/wrapping/tests/statismoTests/TestStatisticalModel.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestStatisticalModel.py
@@ -157,31 +157,15 @@ class Test(unittest.TestCase):
         self.assertEqual(newModelSub.GetNumberOfPrincipalComponents(), 2)
         self.assertTrue((newModelSub.GetPCAVarianceVector()[0:1] == self.model.GetPCAVarianceVector()[0:1]).all)
         self.assertTrue((abs(newModelSub.GetPCABasisMatrix()[:,0:1] - self.model.GetPCABasisMatrix()[:,0:1]) < 1e-3).all())
-  
-  
-  
-    def testDatasetToSample(self):
-         """ Checks wheter DatasetToSample applied to a Sample returns the same sample """
-           
-         meanSample = self.model.DrawMean()
-         meanSampleNew = self.model.DatasetToSample(meanSample)
-         num_pts = meanSample.GetNumberOfPoints()
-         pt_ids = xrange(0, num_pts, num_pts / 10) 
-   
-         for ptId in pt_ids:
-            mp = meanSample.GetPoints().GetPoint(ptId)
-            mpn = meanSampleNew.GetPoints().GetPoint(ptId)
-            self.assertTrue((mp[0] ==  mpn[0]) and  (mp[1] == mpn[1]) and (mp[2] == mpn[2]))
-          
-      
+
     def testProbabilityOfDatasetPlausibility(self):
         num_samples = 100
         nComps = self.model.GetNumberOfPrincipalComponents()
-        p_mean = self.model.ComputeProbabilityOfDataset(self.model.DrawMean())
+        p_mean = self.model.ComputeProbability(self.model.DrawMean())
         for i in xrange(0, num_samples):
             coeffs = randn(nComps)
             s = self.model.DrawSample(coeffs)
-            p = self.model.ComputeProbabilityOfDataset(s)
+            p = self.model.ComputeProbability(s)
 
             # as the distribution we are looking for is just a standard mv normal, all the
             # components are independent. We can thus use a 1d normal distribution to compute the
@@ -198,19 +182,19 @@ class Test(unittest.TestCase):
         for i in xrange(0, num_samples):
             coeffs = randn(self.model.GetNumberOfPrincipalComponents())
             s = self.model.DrawSample(coeffs)
-            p = self.model.ComputeProbabilityOfDataset(s)
-            lp = self.model.ComputeLogProbabilityOfDataset(s)
+            p = self.model.ComputeProbability(s)
+            lp = self.model.ComputeLogProbability(s)
             self.assertTrue(log(p) -lp < 0.05, "Log probability should roughtly equal the log of the probability")
          
     def testMahalanobisDistanceComputation(self):
     	mean = self.model.DrawMean()
-    	mdMean = self.model.ComputeMahalanobisDistanceForDataset(mean)
+    	mdMean = self.model.ComputeMahalanobisDistance(mean)
     	self.assertEqual(mdMean, 0)
          
     	coeffs = zeros(self.model.GetNumberOfPrincipalComponents())
     	coeffs[0] = 3
     	s = self.model.DrawSample(coeffs)
-    	mdSample = self.model.ComputeMahalanobisDistanceForDataset(s)
+    	mdSample = self.model.ComputeMahalanobisDistance(s)
     	self.assertAlmostEqual(mdSample, 3, places=3)
 
 
@@ -218,7 +202,7 @@ class Test(unittest.TestCase):
     def testCoefficientsGenerateCorrectDataset(self):
         coeffs = randn(self.model.GetNumberOfPrincipalComponents())
         s = self.model.DrawSample(coeffs)
-        computed_coeffs = self.model.ComputeCoefficientsForDataset(s)
+        computed_coeffs = self.model.ComputeCoefficients(s)
         diff = (coeffs - computed_coeffs)[:-1] # we ignore the last coefficient
         self.assertTrue((diff < 1e-3).all()) #don't make the threshold too small, as we are dealing with floats
               

--- a/modules/core/include/DataManager.h
+++ b/modules/core/include/DataManager.h
@@ -103,8 +103,7 @@ class CrossValidationFold {
  * to leave a few datasets out to validate the model. For this purpose, the DataManager class implements basic
  * crossvalidation functionality.
  *
- * Note that while Dataset are provided, the Representer class automatically converts them into Samples (Representer::DatasetToSample)
- * For efficiency purposes, the data is internally stored as a large matrix, using the internal SampleVector representation (Representer::DatasetToSample).
+ * For efficiency purposes, the data is internally stored as a large matrix, using the internal SampleVector representation.
  * Furthermore, Statismo emphasizes on traceability, and ties information with the datasets, such as the original filename.
  * This means that when accessing the data stored in the DataManager, one gets a DataItem structure
  * \sa Representer

--- a/modules/core/include/PosteriorModelBuilder.hxx
+++ b/modules/core/include/PosteriorModelBuilder.hxx
@@ -253,7 +253,7 @@ PosteriorModelBuilder<T>::BuildNewModelFromModel(
         for (unsigned i = 0; i < inputScores.cols(); i++) {
             // reconstruct the sample from the input model and project it back into the model
             typename RepresenterType::DatasetPointerType ds = inputModel->DrawSample(inputScores.col(i));
-            scores.col(i) = PosteriorModel->ComputeCoefficientsForDataset(ds);
+            scores.col(i) = PosteriorModel->ComputeCoefficients(ds);
             representer->DeleteDataset(ds);
         }
     }

--- a/modules/core/include/StatisticalModel.h
+++ b/modules/core/include/StatisticalModel.h
@@ -229,17 +229,6 @@ class StatisticalModel {
     ///@{
 
 
-    /**
-     * Returns a sample for the given Dataset by calling the representers internal functions.
-     * The resulting sample will have the same topology and alignment as all the other samples in the model.
-     *
-     * The exact semantics of this call depends on the representer. It typically includes a
-     * rigid alignment of the dataset to the model but could even reparametrization or registration.
-     *
-     * \param dataset
-     * \returns A new sample corresponding to the dataset
-     */
-    DatasetPointerType DatasetToSample(DatasetConstPointerType dataset) const;
 
     /**
      * Returns the value of the given sample at the point specified with the ptId
@@ -397,10 +386,10 @@ class StatisticalModel {
      * \f$
      *
      *
-     * \param datatset The dataset
+     * \param dataset The dataset
      * \return The probability
      */
-    double ComputeProbabilityOfDataset(DatasetConstPointerType dataset) const ;
+    double ComputeProbability(DatasetConstPointerType dataset) const ;
 
     /**
      * Returns the log probability of observing a given dataset.
@@ -409,7 +398,7 @@ class StatisticalModel {
      * \return The log probability
      *
      */
-    double ComputeLogProbabilityOfDataset(DatasetConstPointerType dataset) const ;
+    double ComputeLogProbability(DatasetConstPointerType dataset) const ;
 
 
     /**
@@ -438,29 +427,17 @@ class StatisticalModel {
     /**
       * Returns the mahalonoibs distance for the given dataset.
       */
-    double ComputeMahalanobisDistanceForDataset(DatasetConstPointerType dataset) const;
-
-    /**
-     *
-     * Converts the given dataset to a sample of the model and compute the latent variable
-     * coefficients of this sample under the model.
-     *
-     * @param dataset The dataset
-     *
-     * @returns The coefficient vectro \f$\alpha\f$
-     * \sa ComputeCoefficientsForDataset
-     */
-    VectorType ComputeCoefficientsForDataset(DatasetConstPointerType dataset) const;
+    double ComputeMahalanobisDistance(DatasetConstPointerType dataset) const;
 
 
     /**
-     * Returns the coefficients of the latent variables for the given sample, i.e.
+     * Returns the coefficients of the latent variables for the given dataset, i.e.
      * the vectors of numbers \f$\alpha \f$, such that for the dataset \f$S\f$ it holds that
      * \f$ S = \mu + U \alpha\f$
      *
-     * @returns The coefficient vectro \f$\alpha\f$
+     * @returns The coefficient vector \f$\alpha\f$
      */
-    VectorType ComputeCoefficientsForSample(DatasetConstPointerType sample) const;
+    VectorType ComputeCoefficients(DatasetConstPointerType dataset) const;
 
 
     /**
@@ -474,11 +451,6 @@ class StatisticalModel {
      * \param pointValues A list with PointValuePairs .
      * \param pointValueNoiseVariance The variance of estimated (gaussian) noise at the known points
      *
-     * \warning While in the method ComputeCoefficientsForDataset the Representer is called to do the
-     * necesary alignment steps, this cannot be done for this method. Make sure that the points you provide
-     * are already aligned and in correspondence with the model.
-     *
-     * \sa ComputeCoefficientsForDataset
      */
     VectorType ComputeCoefficientsForPointValues(const PointValueListType&  pointValues, double pointValueNoiseVariance=0.0) const;
 
@@ -495,11 +467,6 @@ class StatisticalModel {
     *
     * \param pointValuesWithCovariance A list with PointValuePairs and PointCovarianceMatrices.
     *
-    * \warning While in the method ComputeCoefficientsForDataset the Representer is called to do the
-    * necesary alignment steps, this cannot be done for this method. Make sure that the points you provide
-    * are already aligned and in correspondence with the model.
-    *
-    * \sa ComputeCoefficientsForDataset
     */
     VectorType ComputeCoefficientsForPointValuesWithCovariance(const PointValueWithCovarianceListType&  pointValuesWithCovariance) const;
 
@@ -514,20 +481,6 @@ class StatisticalModel {
     //RB: I had to modify the method name, to avoid prototype collisions when the PointType corresponds to unsigned (= type of the point id)
     VectorType ComputeCoefficientsForPointIDValues(const PointIdValueListType&  pointValues, double pointValueNoiseVariance=0.0) const;
 
-    /**
-     * Computes the coefficients of the latent variables in a robust way.
-     * Instead of assuming Normally distributed noise on the data set points such as it is
-     * implicitely assumed in the ComputeCoefficientsForDataset, A student-t distribution is assumed for the noise.
-     * The solution is obtained using an EM algorithm.
-     *
-     * \param dataset The dataset
-     * \param nIterations The number of iterations for the EM algorithm
-     * \param nu The number of degrees of Freedom for the Student-t distribution defining the noise model
-     * \param sigma2 The scale parameter of the t-distribution
-     *
-     */
-    VectorType RobustlyComputeCoefficientsForDataset(DatasetConstPointerType dataset, unsigned nIterations=100, unsigned nu=6, double sigma2=1) const;
-    ///@}
 
     /**
      * @name Low level access

--- a/modules/core/include/TrivialVectorialRepresenter.h
+++ b/modules/core/include/TrivialVectorialRepresenter.h
@@ -143,9 +143,6 @@ class TrivialVectorialRepresenter : public Representer<statismo::VectorType> {
         v(0) = pt.ptId;
         return v;
     }
-    DatasetPointerType DatasetToSample(DatasetConstPointerType ds) const {
-        return ds;
-    }
     VectorType SampleToSampleVector(DatasetConstPointerType sample) const {
         return sample;
     }


### PR DESCRIPTION
So far there was the distinction between Dataset (not necessarily aligned) and Sample (aligned), but the DatasetToSample function was rather constrained due to the function only getting access to one element at a time.

@marcelluethi asked me if I could remove that and rename functions to something more neural when they previously were marked as for a Sample or for a Dataset. 


Note: This will break some existing programs using this library: those programs will have to be updated.
Note2: I don't really know what more to write about this commit... 