### PR TITLE
LowRankGPModelBuilder: get norm of eigenvectors and scale them and ei…

### DIFF
--- a/modules/core/include/LowRankGPModelBuilder.h
+++ b/modules/core/include/LowRankGPModelBuilder.h
@@ -203,9 +203,14 @@ class LowRankGPModelBuilder: public ModelBuilder<T> {
                                res.resultForPoints;
             delete futvec[i];
         }
-
-
         VectorType pcaVariance = nystrom->getEigenvalues();
+        VectorType pcaBasisNorm = pcaBasis.colwise().norm();
+        for (unsigned i = 0; i < pcaBasisNorm.size(); i++) {
+	  pcaBasis.col(i) /= pcaBasisNorm[i];
+	  pcaVariance[i] /= pcaBasisNorm[i];
+        }
+	
+        
 
         RowVectorType mu = m_representer->SampleToSampleVector(mean);
 


### PR DESCRIPTION
After computing of pcaBasis, eigenvalues and eigenvectors are scaled by the respective vector norms. 
Fixes #242