### PR TITLE
change Load/Save to Load/SaveStatisticalModel

### DIFF
--- a/modules/ITK/cli/statismo-build-deformation-model.cxx
+++ b/modules/ITK/cli/statismo-build-deformation-model.cxx
@@ -170,7 +170,7 @@ void buildAndSaveDeformationModel(programOptions opt) {
     typedef itk::PCAModelBuilder<ImageType> ModelBuilderType;
     typename ModelBuilderType::Pointer pcaModelBuilder = ModelBuilderType::New();
     model = pcaModelBuilder->BuildNewModel(dataManager->GetData(), opt.fNoiseVariance, opt.bComputeScores);
-    itk::StatismoIO<ImageType>::Save(model, opt.strOutputFileName.c_str());
+    itk::StatismoIO<ImageType>::SaveStatisticalModel(model, opt.strOutputFileName.c_str());
 }
 
 po::options_description initializeProgramOptions(programOptions& poParameters) {

--- a/modules/ITK/cli/statismo-build-gp-model.cxx
+++ b/modules/ITK/cli/statismo-build-gp-model.cxx
@@ -205,7 +205,8 @@ void buildAndSaveModel(programOptions opt) {
 
     if(opt.strOptionalModelPath != "") {
         try {
-            pRawStatisticalModel.reset(statismo::IO<DataType>::Load(pRepresenter.GetPointer(), opt.strOptionalModelPath.c_str()));
+            pRawStatisticalModel.reset(statismo::IO<DataType>::LoadStatisticalModel(pRepresenter.GetPointer(),
+                                                                                    opt.strOptionalModelPath.c_str()));
             pStatModelKernel.reset(new statismo::StatisticalModelKernel<DataType>(pRawStatisticalModel.get()));
             pModelBuildingKernel.reset(new statismo::SumKernel<PointType>(pStatModelKernel.get(), pScaledKernel.get()));
         } catch (statismo::StatisticalModelException& s) {

--- a/modules/ITK/cli/statismo-build-gp-model.cxx
+++ b/modules/ITK/cli/statismo-build-gp-model.cxx
@@ -229,7 +229,7 @@ void buildAndSaveModel(programOptions opt) {
     typename StatisticalModelType::Pointer pModel;
     pModel = gpModelBuilder->BuildNewModel(pMean, *pModelBuildingKernel.get(), opt.iNrOfBasisFunctions);
 
-    itk::StatismoIO<DataType>::Save(pModel, opt.strOutputFileName.c_str());
+    itk::StatismoIO<DataType>::SaveStatisticalModel(pModel, opt.strOutputFileName.c_str());
 }
 
 string getAvailableKernelsStr() {

--- a/modules/ITK/cli/statismo-build-shape-model.cxx
+++ b/modules/ITK/cli/statismo-build-shape-model.cxx
@@ -213,7 +213,7 @@ void buildAndSaveShapeModel(programOptions opt) {
     typedef itk::PCAModelBuilder<MeshType> PCAModelBuilder;
     PCAModelBuilder::Pointer pcaModelBuilder = PCAModelBuilder::New();
     model = pcaModelBuilder->BuildNewModel(dataManager->GetData(), opt.fNoiseVariance);
-    itk::StatismoIO<MeshType>::Save(model, opt.strOutputFileName.c_str());
+    itk::StatismoIO<MeshType>::SaveStatisticalModel(model, opt.strOutputFileName.c_str());
 }
 
 po::options_description initializeProgramOptions(programOptions& poParameters) {

--- a/modules/ITK/cli/statismo-fit-image.cxx
+++ b/modules/ITK/cli/statismo-fit-image.cxx
@@ -224,7 +224,7 @@ void fitImage(programOptions opt, ConsoleOutputSilencer* pCOSilencer) {
 
     typedef itk::StatisticalModel<VectorImageType> StatisticalModelType;
     typename StatisticalModelType::Pointer pModel = StatisticalModelType::New();
-    pModel = itk::StatismoIO<VectorImageType>::Load(pRepresenter, opt.strInputModelFileName.c_str());
+    pModel = itk::StatismoIO<VectorImageType>::LoadStatisticalModel(pRepresenter, opt.strInputModelFileName.c_str());
 
     typedef itk::Transform<double, Dimensions, Dimensions> TransformType;
     typename TransformType::Pointer pTransform;

--- a/modules/ITK/cli/statismo-fit-surface.cxx
+++ b/modules/ITK/cli/statismo-fit-surface.cxx
@@ -225,7 +225,8 @@ void fitMesh(programOptions opt, ConsoleOutputSilencer* pCOSilencer) {
     typedef itk::StandardMeshRepresenter<float, Dimensions> RepresenterType;
     RepresenterType::Pointer pRepresenter = RepresenterType::New();
     StatisticalModelType::Pointer pModel = StatisticalModelType::New();
-    pModel = itk::StatismoIO<DataType>::Load(pRepresenter.GetPointer(), opt.strInputModelFileName.c_str());
+    pModel = itk::StatismoIO<DataType>::LoadStatisticalModel(pRepresenter.GetPointer(),
+                                                             opt.strInputModelFileName.c_str());
 
     StatisticalModelType::Pointer pConstrainedModel;
     typedef itk::StatisticalShapeModelTransform<DataType, double, Dimensions> StatisticalModelTransformType;

--- a/modules/ITK/cli/statismo-posterior.cxx
+++ b/modules/ITK/cli/statismo-posterior.cxx
@@ -173,7 +173,8 @@ void buildPosteriorShapeModel(programOptions& opt) {
     typedef itk::StandardMeshRepresenter<float, Dimensionality3D> RepresenterType;
     RepresenterType::Pointer pRepresenter = RepresenterType::New();
     StatisticalModelType::Pointer pModel = StatisticalModelType::New();
-    pModel = itk::StatismoIO<DataType>::Load(pRepresenter.GetPointer(), opt.strInputModelFileName.c_str());
+    pModel = itk::StatismoIO<DataType>::LoadStatisticalModel(pRepresenter.GetPointer(),
+                                                             opt.strInputModelFileName.c_str());
 
     StatisticalModelType::Pointer pConstrainedModel;
     if (opt.strInputMeshFileName == "") {
@@ -188,7 +189,7 @@ void buildPosteriorShapeModel(programOptions& opt) {
         pConstrainedModel = buildPosteriorShapeModel<DataType, StatisticalModelType>(pModel, pMeshInCorrespondence, opt.dVariance);
     }
 
-    itk::StatismoIO<DataType>::Save(pConstrainedModel, opt.strOutputModelFileName.c_str());
+    itk::StatismoIO<DataType>::SaveStatisticalModel(pConstrainedModel, opt.strOutputModelFileName.c_str());
 }
 
 template<unsigned Dimensionality>
@@ -199,12 +200,13 @@ void buildPosteriorDeformationModel(programOptions& opt) {
     typedef itk::StandardImageRepresenter<VectorPixelType, Dimensionality> RepresenterType;
     typename RepresenterType::Pointer pRepresenter = RepresenterType::New();
     typename StatisticalModelType::Pointer pModel = StatisticalModelType::New();
-    pModel = itk::StatismoIO<DataType>::Load(pRepresenter.GetPointer(), opt.strInputModelFileName.c_str());
+    pModel = itk::StatismoIO<DataType>::LoadStatisticalModel(pRepresenter.GetPointer(),
+                                                             opt.strInputModelFileName.c_str());
 
     typename StatisticalModelType::Pointer pConstrainedModel;
     pConstrainedModel = buildPosteriorDeformationModel<DataType, StatisticalModelType>(pModel, opt.strInputFixedLandmarksFileName, opt.strInputMovingLandmarksFileName, opt.dVariance);
 
-    itk::StatismoIO<DataType>::Save(pConstrainedModel, opt.strOutputModelFileName.c_str());
+    itk::StatismoIO<DataType>::SaveStatisticalModel(pConstrainedModel, opt.strOutputModelFileName.c_str());
 }
 
 

--- a/modules/ITK/cli/statismo-reduce-model.cxx
+++ b/modules/ITK/cli/statismo-reduce-model.cxx
@@ -162,7 +162,7 @@ void reduceModel(programOptions opt) {
     typedef typename itk::StatisticalModel<DataType> StatisticalModelType;
     typename StatisticalModelType::Pointer pModel = StatisticalModelType::New();
 
-    pModel = itk::StatismoIO<DataType>::Load(pRepresenter, opt.strInputFileName.c_str());
+    pModel = itk::StatismoIO<DataType>::LoadStatisticalModel(pRepresenter, opt.strInputFileName.c_str());
 
     typedef typename itk::ReducedVarianceModelBuilder<DataType> ReducedVarianceModelBuilderType;
     typename ReducedVarianceModelBuilderType::Pointer pReducedVarModelBuilder = ReducedVarianceModelBuilderType::New();
@@ -177,7 +177,7 @@ void reduceModel(programOptions opt) {
         pOutputModel = pReducedVarModelBuilder->BuildNewModelWithVariance(pModel.GetPointer(), opt.dTotalVariance);
     }
 
-    itk::StatismoIO<DataType>::Save(pOutputModel, opt.strOutputFileName.c_str());
+    itk::StatismoIO<DataType>::SaveStatisticalModel(pOutputModel, opt.strOutputFileName.c_str());
 }
 
 

--- a/modules/ITK/cli/statismo-sample.cxx
+++ b/modules/ITK/cli/statismo-sample.cxx
@@ -203,7 +203,7 @@ void drawSampleFromModel(programOptions opt) {
     typedef itk::StatisticalModel<DataType> StatisticalModelType;
     typename StatisticalModelType::Pointer pModel = StatisticalModelType::New();
 
-    pModel = itk::StatismoIO<DataType>::Load(pRepresenter, opt.strInputFileName.c_str());
+    pModel = itk::StatismoIO<DataType>::LoadStatisticalModel(pRepresenter, opt.strInputFileName.c_str());
 
     typename DataType::Pointer output;
     if (opt.bSampleMean == true) {

--- a/modules/ITK/examples/itkBuildDeformationModel.cxx
+++ b/modules/ITK/examples/itkBuildDeformationModel.cxx
@@ -120,7 +120,7 @@ void itkExample(const char* dir, const char* modelname, double noiseVariance) {
 
     typename ModelBuilderType::Pointer pcaModelBuilder = ModelBuilderType::New();
     typename StatisticalModelType::Pointer model = pcaModelBuilder->BuildNewModel(dataManager->GetData(), noiseVariance);
-    itk::StatismoIO<ImageType>::Save(model, modelname);
+    itk::StatismoIO<ImageType>::SaveStatisticalModel(model, modelname);
 
 }
 

--- a/modules/ITK/examples/itkBuildGaussianProcessDeformationModel.cxx
+++ b/modules/ITK/examples/itkBuildGaussianProcessDeformationModel.cxx
@@ -129,7 +129,7 @@ void itkExample(const char* referenceFilename, double gaussianKernelSigma, const
     typename ModelBuilderType::Pointer gpModelBuilder = ModelBuilderType::New();
     gpModelBuilder->SetRepresenter(representer);
     typename StatisticalModelType::Pointer model = gpModelBuilder->BuildNewZeroMeanModel(scaledGk, 100);
-    itk::StatismoIO<ImageType>::Save(model, modelname);
+    itk::StatismoIO<ImageType>::SaveStatisticalModel(model, modelname);
 }
 
 int main(int argc, char* argv[]) {

--- a/modules/ITK/examples/itkBuildShapeModel.cxx
+++ b/modules/ITK/examples/itkBuildShapeModel.cxx
@@ -111,7 +111,7 @@ void buildShapeModel(const char* referenceFilename, const char* dir, const char*
 
     ModelBuilderType::Pointer pcaModelBuilder = ModelBuilderType::New();
     StatisticalModelType::Pointer model = pcaModelBuilder->BuildNewModel(dataManager->GetData(), 0);
-    itk::StatismoIO<MeshType>::Save(model, modelname);
+    itk::StatismoIO<MeshType>::SaveStatisticalModel(model, modelname);
 
 
 

--- a/modules/ITK/examples/itkBuildShapeModel_75pcvar.cxx
+++ b/modules/ITK/examples/itkBuildShapeModel_75pcvar.cxx
@@ -120,7 +120,7 @@ void buildShapeModel(const char* referenceFilename, const char* dir, const char*
     std::cout<<"number of modes in the direct model: " <<model->GetNumberOfPrincipalComponents()
              <<", and in the reduced model: "<< reducedModel->GetNumberOfPrincipalComponents() << std::endl;
 
-    itk::StatismoIO<MeshType>::Save(reducedModel ,modelname);
+    itk::StatismoIO<MeshType>::SaveStatisticalModel(reducedModel, modelname);
 
 
 

--- a/modules/ITK/examples/itkDeformationModelFitting.cxx
+++ b/modules/ITK/examples/itkDeformationModelFitting.cxx
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
 
     RepresenterType::Pointer representer = RepresenterType::New();
     StatisticalModelType::Pointer model = StatisticalModelType::New();
-    model = itk::StatismoIO<VectorImageType>::Load(representer, modelname);
+    model = itk::StatismoIO<VectorImageType>::LoadStatisticalModel(representer, modelname);
 
     // do the fitting
     TransformType::Pointer transform = TransformType::New();

--- a/modules/ITK/examples/itkLandmarkConstrainedShapeModelFitting.cxx
+++ b/modules/ITK/examples/itkLandmarkConstrainedShapeModelFitting.cxx
@@ -311,7 +311,7 @@ int main(int argc, char* argv[]) {
     // load the model create a shape model transform with it
     StatisticalModelType::Pointer model = StatisticalModelType::New();
     RepresenterType::Pointer representer = RepresenterType::New();
-    model = itk::StatismoIO<MeshType>::Load(representer, modelName);
+    model = itk::StatismoIO<MeshType>::LoadStatisticalModel(representer, modelName);
 
     StatisticalModelType::Pointer constraintModel = computePosteriorModel(rigidTransform, model, fixedLandmarks, movingLandmarks, lmVariance);
 

--- a/modules/ITK/examples/itkShapeModelFitting.cxx
+++ b/modules/ITK/examples/itkShapeModelFitting.cxx
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
     // load the model
     RepresenterType::Pointer representer = RepresenterType::New();
     StatisticalModelType::Pointer model = StatisticalModelType::New();
-    model = itk::StatismoIO<MeshType>::Load(representer, modelname);
+    model = itk::StatismoIO<MeshType>::LoadStatisticalModel(representer, modelname);
     MeshType::Pointer fixedPointSet  = model->GetRepresenter()->GetReference();
     std::cout << "model succesully loaded " << std::endl;
 

--- a/modules/ITK/include/itkStatismoIO.h
+++ b/modules/ITK/include/itkStatismoIO.h
@@ -59,7 +59,7 @@ class StatismoIO {
             unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
         try {
             ITKStatisticalModelTypePointer pModel = ITKStatisticalModelType::New();
-            pModel->SetstatismoImplObj(statismo::IO<T>::Load(representer, filename, maxNumberOfPCAComponents));
+            pModel->SetstatismoImplObj(statismo::IO<T>::LoadStatisticalModel(representer, filename, maxNumberOfPCAComponents));
             return pModel;
         } catch (const statismo::StatisticalModelException& e) {
             itkGenericExceptionMacro(<< e.what());
@@ -71,7 +71,7 @@ class StatismoIO {
             unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
         try {
             ITKStatisticalModelTypePointer pModel = ITKStatisticalModelType::New();
-            pModel->SetstatismoImplObj(statismo::IO<T>::Load(representer, modelRoot, maxNumberOfPCAComponents));
+            pModel->SetstatismoImplObj(statismo::IO<T>::LoadStatisticalModel(representer, modelRoot, maxNumberOfPCAComponents));
             return pModel;
         } catch (const statismo::StatisticalModelException& e) {
             itkGenericExceptionMacro(<< e.what());
@@ -80,7 +80,7 @@ class StatismoIO {
 
     static void SaveStatisticalModel(const ITKStatisticalModelType *const model, const std::string &filename) {
         try {
-            statismo::IO<T>::Save(model->GetstatismoImplObj(), filename);
+            statismo::IO<T>::SaveStatisticalModel(model->GetstatismoImplObj(), filename);
         } catch (const statismo::StatisticalModelException& e) {
             itkGenericExceptionMacro(<< e.what());
         }
@@ -88,7 +88,7 @@ class StatismoIO {
 
     static void SaveStatisticalModel(const ITKStatisticalModelType *model, const H5::Group &modelRoot) {
         try {
-            statismo::IO<T>::Save(model->GetstatismoImplObj(), modelRoot);
+            statismo::IO<T>::SaveStatisticalModel(model->GetstatismoImplObj(), modelRoot);
         } catch (const statismo::StatisticalModelException& e) {
             itkGenericExceptionMacro(<< e.what());
         }

--- a/modules/ITK/include/itkStatismoIO.h
+++ b/modules/ITK/include/itkStatismoIO.h
@@ -54,7 +54,9 @@ class StatismoIO {
     typedef typename ITKStatisticalModelType::Pointer   ITKStatisticalModelTypePointer;
 
   public:
-    static ITKStatisticalModelTypePointer Load(typename StatisticalModelType::RepresenterType* representer, const std::string& filename, unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
+    static ITKStatisticalModelTypePointer LoadStatisticalModel(
+            typename StatisticalModelType::RepresenterType *representer, const std::string &filename,
+            unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
         try {
             ITKStatisticalModelTypePointer pModel = ITKStatisticalModelType::New();
             pModel->SetstatismoImplObj(statismo::IO<T>::Load(representer, filename, maxNumberOfPCAComponents));
@@ -64,7 +66,9 @@ class StatismoIO {
         }
     }
 
-    static ITKStatisticalModelTypePointer Load(typename ITKStatisticalModelType::RepresenterType* representer, const H5::Group& modelRoot, unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
+    static ITKStatisticalModelTypePointer LoadStatisticalModel(
+            typename ITKStatisticalModelType::RepresenterType *representer, const H5::Group &modelRoot,
+            unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
         try {
             ITKStatisticalModelTypePointer pModel = ITKStatisticalModelType::New();
             pModel->SetstatismoImplObj(statismo::IO<T>::Load(representer, modelRoot, maxNumberOfPCAComponents));
@@ -74,7 +78,7 @@ class StatismoIO {
         }
     }
 
-    static void Save(const ITKStatisticalModelType* const model, const std::string& filename) {
+    static void SaveStatisticalModel(const ITKStatisticalModelType *const model, const std::string &filename) {
         try {
             statismo::IO<T>::Save(model->GetstatismoImplObj(), filename);
         } catch (const statismo::StatisticalModelException& e) {
@@ -82,7 +86,7 @@ class StatismoIO {
         }
     }
 
-    static void Save(const ITKStatisticalModelType* model, const H5::Group& modelRoot) {
+    static void SaveStatisticalModel(const ITKStatisticalModelType *model, const H5::Group &modelRoot) {
         try {
             statismo::IO<T>::Save(model->GetstatismoImplObj(), modelRoot);
         } catch (const statismo::StatisticalModelException& e) {

--- a/modules/VTK/examples/vtkBasicSamplingExample.cxx
+++ b/modules/VTK/examples/vtkBasicSamplingExample.cxx
@@ -83,7 +83,8 @@ int main(int argc, char** argv) {
         // To load a model, we call the static Load method, which returns (a pointer to) a
         // new StatisticalModel object
         RepresenterType* representer = RepresenterType::Create();
-        boost::scoped_ptr<StatisticalModelType> model(statismo::IO<vtkPolyData>::Load(representer, modelname));
+        boost::scoped_ptr<StatisticalModelType> model(
+                statismo::IO<vtkPolyData>::LoadStatisticalModel(representer, modelname));
         std::cout << "loaded model with " << model->GetNumberOfPrincipalComponents() << " Principal Components" << std::endl;
 
 

--- a/modules/VTK/examples/vtkBuildConditionalModelExample.cxx
+++ b/modules/VTK/examples/vtkBuildConditionalModelExample.cxx
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
 
         // The resulting model is a normal statistical model, from which we could for example sample examples.
         // Here we simply  save it to disk for later use.
-        statismo::IO<vtkStructuredPoints>::Save(model.get(), modelname);
+        statismo::IO<vtkStructuredPoints>::SaveStatisticalModel(model.get(), modelname);
         reference->Delete();
         std::cout << "save model as " << modelname << std::endl;
     } catch (StatisticalModelException& e) {

--- a/modules/VTK/examples/vtkBuildGaussianProcessShapeModelExample.cxx
+++ b/modules/VTK/examples/vtkBuildGaussianProcessShapeModelExample.cxx
@@ -120,7 +120,8 @@ int main(int argc, char** argv) {
         // we load an existing statistical model and create a StatisticalModelKernel from it. The statisticlModelKernel
         // takes the covariance (matrix) of the model and defines a kernel function from it.
         vtkStandardMeshRepresenter* representer = vtkStandardMeshRepresenter::Create();
-        boost::scoped_ptr<StatisticalModelType> model(statismo::IO<vtkPolyData>::Load(representer, modelFilename));
+        boost::scoped_ptr<StatisticalModelType> model(
+                statismo::IO<vtkPolyData>::LoadStatisticalModel(representer, modelFilename));
         const MatrixValuedKernelType& statModelKernel = StatisticalModelKernel<vtkPolyData>(model.get());
 
         // Create a (scalar valued) gaussian kernel. This kernel is then made matrix-valued. We use a UncorrelatedMatrixValuedKernel,
@@ -141,7 +142,7 @@ int main(int argc, char** argv) {
         boost::scoped_ptr<StatisticalModelType> combinedModel(modelBuilder->BuildNewModel(model->DrawMean(), combinedModelAndGaussKernel, numberOfComponents));
 
         // Once we have built the model, we can save it to disk.
-        statismo::IO<vtkPolyData>::Save(combinedModel.get(), outputModelFilename);
+        statismo::IO<vtkPolyData>::SaveStatisticalModel(combinedModel.get(), outputModelFilename);
         std::cout << "Successfully saved shape model as " << outputModelFilename << std::endl;
 
     } catch (StatisticalModelException& e) {

--- a/modules/VTK/examples/vtkBuildIntensityModelExample.cxx
+++ b/modules/VTK/examples/vtkBuildIntensityModelExample.cxx
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
         }
         boost::scoped_ptr<ModelBuilderType> modelBuilder(ModelBuilderType::Create());
         boost::scoped_ptr<StatisticalModelType> model(modelBuilder->BuildNewModel(dataManager->GetData(), 0.01));
-        statismo::IO<vtkStructuredPoints>::Save(model.get(), modelname);
+        statismo::IO<vtkStructuredPoints>::SaveStatisticalModel(model.get(), modelname);
 
         reference->Delete();
         std::cout << "Successfully saved model as " << modelname << std::endl;

--- a/modules/VTK/examples/vtkBuildPosteriorModelExample.cxx
+++ b/modules/VTK/examples/vtkBuildPosteriorModelExample.cxx
@@ -117,7 +117,8 @@ int main(int argc, char** argv) {
         vtkPolyData* partialShape = loadVTKPolyData(partialShapeMeshName);
 
         RepresenterType* representer = RepresenterType::Create();
-        boost::scoped_ptr<StatisticalModelType> inputModel(statismo::IO<vtkPolyData>::Load(representer, inputModelName));
+        boost::scoped_ptr<StatisticalModelType> inputModel(
+                statismo::IO<vtkPolyData>::LoadStatisticalModel(representer, inputModelName));
         vtkPolyData* refPd = const_cast<vtkPolyData*>(inputModel->GetRepresenter()->GetReference());
 
 
@@ -147,7 +148,7 @@ int main(int argc, char** argv) {
 
         // The resulting model is a normal statistical model, from which we could for example sample examples.
         // Here we simply  save it to disk for later use.
-        statismo::IO<vtkPolyData>::Save(constraintModel.get(), posteriorModelName);
+        statismo::IO<vtkPolyData>::SaveStatisticalModel(constraintModel.get(), posteriorModelName);
         std::cout << "successfully saved the model to " << posteriorModelName << std::endl;
 
         // The mean of the constraint model is the optimal reconstruction

--- a/modules/VTK/examples/vtkBuildShapeModelExample.cxx
+++ b/modules/VTK/examples/vtkBuildShapeModelExample.cxx
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
         boost::scoped_ptr<StatisticalModelType> model(modelBuilder->BuildNewModel(dataManager->GetData(), 0.01));
 
         // Once we have built the model, we can save it to disk.
-        statismo::IO<vtkPolyData>::Save(model.get(), modelname);
+        statismo::IO<vtkPolyData>::SaveStatisticalModel(model.get(), modelname);
         std::cout << "Successfully saved shape model as " << modelname << std::endl;
 
         reference->Delete();

--- a/modules/VTK/examples/vtkReduceModelVarianceExample.cxx
+++ b/modules/VTK/examples/vtkReduceModelVarianceExample.cxx
@@ -74,7 +74,8 @@ int main(int argc, char** argv) {
         // To load a model, we call the static Load method, which returns (a pointer to) a
         // new StatisticalModel object
         RepresenterType* representer = RepresenterType::Create();
-        boost::scoped_ptr<StatisticalModelType> model(statismo::IO<vtkPolyData>::Load(representer, inputModelName));
+        boost::scoped_ptr<StatisticalModelType> model(
+                statismo::IO<vtkPolyData>::LoadStatisticalModel(representer, inputModelName));
         std::cout << "loaded model with variance of " << model->GetPCAVarianceVector().sum()  << std::endl;
 
         boost::scoped_ptr<ReducedVarianceModelBuilderType> reducedVarModelBuilder(ReducedVarianceModelBuilderType::Create());
@@ -83,7 +84,7 @@ int main(int argc, char** argv) {
         boost::scoped_ptr<StatisticalModelType> reducedModel(reducedVarModelBuilder->BuildNewModelWithVariance(model.get(), 0.5));
         std::cout << "new model has variance of " << reducedModel->GetPCAVarianceVector().sum()  << std::endl;
 
-        statismo::IO<vtkPolyData>::Save(reducedModel.get(), outputModelName);
+        statismo::IO<vtkPolyData>::SaveStatisticalModel(reducedModel.get(), outputModelName);
     } catch (StatisticalModelException& e) {
         std::cout << "Exception occured while building the shape model" << std::endl;
         std::cout << e.what() << std::endl;

--- a/modules/VTK/examples/vtkSpatiallyVaryingGPModelExample.cxx
+++ b/modules/VTK/examples/vtkSpatiallyVaryingGPModelExample.cxx
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
         StatisticalModelType* newModel = modelBuilder->BuildNewModel(referenceMesh, temperedKernel, numberOfComponents);
 
         // Once we have built the model, we can save it to disk.
-        statismo::IO<vtkPolyData>::Save(newModel, outputModelFilename);
+        statismo::IO<vtkPolyData>::SaveStatisticalModel(newModel, outputModelFilename);
         std::cout << "Successfully saved shape model as " << outputModelFilename << std::endl;
 
         referenceMesh->Delete();

--- a/modules/core/include/StatismoIO.h
+++ b/modules/core/include/StatismoIO.h
@@ -66,7 +66,9 @@ class IO {
      * \param maxNumberOfPCAComponents The maximal number of pca components that are loaded
      * to create the model.
      */
-    static StatisticalModelType* Load(typename StatisticalModelType::RepresenterType* representer, const std::string& filename, unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
+    static StatisticalModelType* LoadStatisticalModel(typename StatisticalModelType::RepresenterType *representer,
+                                                      const std::string &filename,
+                                                      unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
 
         StatisticalModelType* newModel = 0;
 
@@ -80,7 +82,7 @@ class IO {
 
         H5::Group modelRoot = file.openGroup("/");
 
-        newModel = Load(representer, modelRoot, maxNumberOfPCAComponents);
+        newModel = LoadStatisticalModel(representer, modelRoot, maxNumberOfPCAComponents);
 
         modelRoot.close();
         file.close();
@@ -94,7 +96,9 @@ class IO {
      * \param maxNumberOfPCAComponents The maximal number of pca components that are loaded
      * to create the model.
      */
-    static StatisticalModelType* Load(typename StatisticalModelType::RepresenterType* representer, const H5::Group& modelRoot, unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
+    static StatisticalModelType* LoadStatisticalModel(typename StatisticalModelType::RepresenterType *representer,
+                                                      const H5::Group &modelRoot,
+                                                      unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max()) {
 
         StatisticalModelType* newModel;
         ModelInfo modelInfo;
@@ -164,11 +168,11 @@ class IO {
      * \param model A pointer to the model you'd like to save.
      * \param filename The filename (preferred extension is .h5)
      * */
-    static void Save(const StatisticalModelType* const model, const std::string& filename) {
+    static void SaveStatisticalModel(const StatisticalModelType *const model, const std::string &filename) {
         if(model == NULL) {
             throw new StatisticalModelException("Passing on a NULL_Pointer when trying to save a model is not possible.");
         }
-        Save(*model, filename);
+        SaveStatisticalModel(*model, filename);
     }
 
     /**
@@ -176,7 +180,7 @@ class IO {
      * \param model The model you'd like to save
      * \param filename The filename (preferred extension is .h5)
      * */
-    static void Save(const StatisticalModelType& model, const std::string& filename) {
+    static void SaveStatisticalModel(const StatisticalModelType &model, const std::string &filename) {
         using namespace H5;
 
         H5File file;
@@ -197,7 +201,7 @@ class IO {
         HDF5Utils::writeInt(versionGroup, "minorVersion", 9);
         versionGroup.close();
 
-        Save(model, modelRoot);
+        SaveStatisticalModel(model, modelRoot);
         modelRoot.close();
         file.close();
     };
@@ -207,7 +211,7 @@ class IO {
      * \param model the model you'd like to save
      * \param modelRoot the group where to store the model
      * */
-    static void Save(const StatisticalModelType& model, const H5::Group& modelRoot) {
+    static void SaveStatisticalModel(const StatisticalModelType &model, const H5::Group &modelRoot) {
         try {
             // create the group structure
 

--- a/modules/core/tests/basicStatismoTest.cxx
+++ b/modules/core/tests/basicStatismoTest.cxx
@@ -85,10 +85,11 @@ int main(int argc, char* argv[]) {
             return EXIT_FAILURE;
         }
 
-        statismo::IO<statismo::VectorType>::Save(model.get(), "test.h5");
+        statismo::IO<statismo::VectorType>::SaveStatisticalModel(model.get(), "test.h5");
 
         RepresenterType* newRepresenter = RepresenterType::Create();
-        boost::scoped_ptr<StatisticalModelType> loadedModel(statismo::IO<statismo::VectorType>::Load(newRepresenter, "test.h5"));
+        boost::scoped_ptr<StatisticalModelType> loadedModel(
+                statismo::IO<statismo::VectorType>::LoadStatisticalModel(newRepresenter, "test.h5"));
         if (model->GetNumberOfPrincipalComponents() != loadedModel->GetNumberOfPrincipalComponents()) {
             return EXIT_FAILURE;
         }


### PR DESCRIPTION
In the PR-from Frank that I merged yesterday, the IO was factored out of the StatisticalModel class into an own IO class. The methods were called Load/Save only. 

We will soon also support Active Shape Models. To be ready for this change, it makes sense to rename these methods to ```LoadStatisticalShapeModel``` and ```SaveStatisticalShapeModel```

@zarquon42b I guess you are already affected by this. Can you merge the PR if this change is okay for you?