### PR TITLE
Included itk_use_file in itk module, to enable code completion in IDEs

### DIFF
--- a/modules/ITK/CMakeLists.txt
+++ b/modules/ITK/CMakeLists.txt
@@ -6,6 +6,7 @@ if(MSVC11) #i.e. Visual Studio 2012
   add_definitions( -D BOOST_NO_0X_HDR_INITIALIZER_LIST )
 endif()
 
+include( ${ITK_USE_FILE} )
 
 include_directories( BEFORE
   ${CMAKE_CURRENT_SOURCE_DIR}/include


### PR DESCRIPTION
Even though itk_use_file was included in a superseding CMakesLists.txt file, Visual Studio did not find the ITK headers. It compiled, but no code completion and navigation was possible.
By including the use file at this level, Visual Studio gets all necessary include directories.