### PR TITLE
Fix VTK python wrapping for newer versions of CMake, VTK and statismo

### DIFF
--- a/modules/VTK/CMakeLists.txt
+++ b/modules/VTK/CMakeLists.txt
@@ -21,13 +21,16 @@ if(VTK_MAJOR_VERSION GREATER 5)
     vtkIOXML
     vtkIOXMLParser
     )
-  list(FIND VTK_MODULES_ENABLED "vtkIOMPIParallel" HasOMPI)
+  if( ${BUILD_WRAPPING} )
+    list( APPEND required_vtk_modules vtkWrappingPythonCore )
+  endif()
 
+  list(FIND VTK_MODULES_ENABLED "vtkIOMPIParallel" HasOMPI)
   if(NOT HasOMPI EQUAL -1)
     list(APPEND required_vtk_modules vtkIOMPIParallel)
   endif()
   find_package( VTK REQUIRED COMPONENTS ${required_vtk_modules} )
-  
+
 else()
   find_package( VTK REQUIRED )
 endif()

--- a/modules/VTK/wrapping/CMakeLists.txt
+++ b/modules/VTK/wrapping/CMakeLists.txt
@@ -17,8 +17,7 @@ link_directories(
   ${HDF5_LIBRARY_DIR}
 )
 
-# The process of wrapping requires some numpy headers.
-# (Not entirely sure what requires it though)
+# The wrapper requires access to numpy headers (see numpy.i).
 exec_program( ${PYTHON_EXECUTABLE}
             ARGS "-c \"import numpy; print(numpy.get_include())\""
             OUTPUT_VARIABLE NUMPY_INCLUDE_DIR

--- a/modules/VTK/wrapping/CMakeLists.txt
+++ b/modules/VTK/wrapping/CMakeLists.txt
@@ -19,19 +19,17 @@ link_directories(
 
 # The process of wrapping requires some numpy headers.
 # (Not entirely sure what requires it though)
-if( True )
-  exec_program( ${PYTHON_EXECUTABLE}
-                ARGS "-c \"import numpy; print(numpy.get_include())\""
-                OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
-                RETURN_VALUE NUMPY_NOT_FOUND
-               )
-  set( NUMPY_INCLUDE_DIR ${NUMPY_INCLUDE_DIR} CACHE STRING "Numpy include path" )
-  MARK_AS_ADVANCED( NUMPY_INCLUDE_DIR )
-  if( NUMPY_NOT_FOUND )
-    message( FATAL_ERROR "Numpy package/header is missing" )
-  else()
-    include_directories( "${NUMPY_INCLUDE_DIR}" )
-  endif()
+exec_program( ${PYTHON_EXECUTABLE}
+            ARGS "-c \"import numpy; print(numpy.get_include())\""
+            OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
+            RETURN_VALUE NUMPY_NOT_FOUND
+           )
+set( NUMPY_INCLUDE_DIR ${NUMPY_INCLUDE_DIR} CACHE STRING "Numpy include path" )
+MARK_AS_ADVANCED( NUMPY_INCLUDE_DIR )
+if( NUMPY_NOT_FOUND )
+message( FATAL_ERROR "Numpy package/header is missing" )
+else()
+include_directories( "${NUMPY_INCLUDE_DIR}" )
 endif()
 
 # Find SWIG

--- a/modules/VTK/wrapping/CMakeLists.txt
+++ b/modules/VTK/wrapping/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_package( PythonLibs REQUIRED )
 include_directories(${PYTHON_INCLUDE_PATH})
 
+# VTK material for linking.
+# See also the list of required modules in ../CMakeLists.txt
 if( VTK_MAJOR_VERSION EQUAL 5 )
   # VTK 5 needs additional libraries
   set( VTK_LIBRARIES_PYTHON
@@ -15,26 +17,47 @@ link_directories(
   ${HDF5_LIBRARY_DIR}
 )
 
+# The process of wrapping requires some numpy headers.
+# (Not entirely sure what requires it though)
+if( True )
+  exec_program( ${PYTHON_EXECUTABLE}
+                ARGS "-c \"import numpy; print(numpy.get_include())\""
+                OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
+                RETURN_VALUE NUMPY_NOT_FOUND
+               )
+  set( NUMPY_INCLUDE_DIR ${NUMPY_INCLUDE_DIR} CACHE STRING "Numpy include path" )
+  MARK_AS_ADVANCED( NUMPY_INCLUDE_DIR )
+  if( NUMPY_NOT_FOUND )
+    message( FATAL_ERROR "Numpy package/header is missing" )
+  else()
+    include_directories( "${NUMPY_INCLUDE_DIR}" )
+  endif()
+endif()
+
+# Find SWIG
 find_package( SWIG REQUIRED )
 include( ${SWIG_USE_FILE} )
 
+# Prepare the wrapping library.
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
+include_directories(${VTK_INCLUDE_DIRS})
 set_source_files_properties(statismo.i PROPERTIES CPLUSPLUS ON)
 set_source_files_properties(statismo.i PROPERTIES SWIG_FLAGS "-includeall")
-
-file( GLOB _Statismo_src
-  ${statismo_SOURCE_DIR}/modules/VTK/src/*.cxx
-)
-
-swig_add_module( statismo_VTK python statismo.i ${_Statismo_src})
-
-swig_link_libraries( statismo_VTK ${PYTHON_LIBRARIES}  statismo_core ${VTK_LIBRARIES} ${VTK_LIBRARIES_PYTHON} ${HDF5_LIBRARIES} )
+file( GLOB _Statismo_src ${statismo_SOURCE_DIR}/modules/VTK/src/*.cxx )
+if( "${CMAKE_VERSION}" VERSION_LESS "3.8.0" )
+  swig_add_module( statismo_VTK python statismo.i ${_Statismo_src} )
+else()
+  swig_add_library( statismo_VTK
+                    MODULE LANGUAGE python
+                    SOURCES statismo.i ${_Statismo_src} )
+endif()
+swig_link_libraries( statismo_VTK statismo_core
+                     ${PYTHON_LIBRARIES}
+                     ${VTK_LIBRARIES} ${VTK_LIBRARIES_PYTHON}
+                     ${HDF5_LIBRARIES} )
 
 set_target_properties( _statismo_VTK PROPERTIES
   DEBUG_POSTFIX "-d"
-  VERSION "${statismo_LIB_VERSION}"
-  SOVERSION "${statismo_LIB_SOVERSION}"
 )
 
 install( TARGETS _statismo_VTK

--- a/modules/VTK/wrapping/statismo.i
+++ b/modules/VTK/wrapping/statismo.i
@@ -34,7 +34,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 %module statismo_VTK
 
 %include "typemaps.i"
@@ -52,7 +52,7 @@
 //%include "vtkStructuredPointsRepresenter.i"
 //%include "TrivialVectorialRepresenter.i"
 
-  
+
 %{
 #include "Representer.h"
 #include "DataManager.h"
@@ -63,15 +63,16 @@
 #include "PCAModelBuilder.h"
 #include "Exceptions.h"
 #include "CommonTypes.h"
+#include "StatismoIO.h"
 #include <list>
 #include <string>
 %}
 
 
-namespace statismo { 
+namespace statismo {
 class StatisticalModelException {
 public:
-	StatisticalModelException(const char* message);
+    StatisticalModelException(const char* message);
 };
 }
 
@@ -84,36 +85,34 @@ public:
    }
 }
 
-
-
 //////////////////////////////////////////////////////
 // DataManager
 //////////////////////////////////////////////////////
 
-namespace statismo { 
+namespace statismo {
 template <typename T>
 struct DataItem {
-	
-	
+
+
     typedef Representer<T> RepresenterType;
     typedef typename RepresenterType::DatasetConstPointerType DatasetConstPointerType;
     typedef typename RepresenterType::DatasetPointerType DatasetPointerType;
 
-	
-	std::string GetDatasetURI() const;
-	%newobject GetSample;
-	const DatasetPointerType GetSample() const;
 
-	const  statismo::VectorType& GetSampleVector() const;
-	virtual ~DataItem();
+    std::string GetDatasetURI() const;
+    %newobject GetSample;
+    const DatasetPointerType GetSample() const;
+
+    const  statismo::VectorType& GetSampleVector() const;
+    virtual ~DataItem();
 private:
-        DataItem(const Representer<T>* representer, const std::string& filename, const statismo::VectorType& sampleVector);
+    DataItem(const Representer<T>* representer, const std::string& filename, const statismo::VectorType& sampleVector);
 };
 
 template <typename T>
-struct DataItemWithSurrogates : public DataItem<T> { 
+struct DataItemWithSurrogates : public DataItem<T> {
         const statismo::VectorType& GetSurrogateVector() const;
-	const std::string& GetSurrogateFilename() const;
+    const std::string& GetSurrogateFilename() const;
 };
 }
 
@@ -129,12 +128,12 @@ struct DataItemWithSurrogates : public DataItem<T> {
 template <typename Representer>
 class CrossValidationFold {
 public:
-	typedef DataItem<Representer> DataItemType;
-	typedef std::list<const DataItemType*> DataItemListType;
+    typedef DataItem<Representer> DataItemType;
+    typedef std::list<const DataItemType*> DataItemListType;
 
-	CrossValidationFold();
-	DataItemListType GetTrainingData() const;
-	DataItemListType GetTestingData() const;
+    CrossValidationFold();
+    DataItemListType GetTrainingData() const;
+    DataItemListType GetTestingData() const;
 
 };
 %template(CrossValidationFold_vtkPD) statismo::CrossValidationFold<vtkPolyData>;
@@ -157,33 +156,33 @@ public:
     typedef typename RepresenterType::DatasetConstPointerType DatasetConstPointerType;
     typedef typename RepresenterType::DatasetPointerType DatasetPointerType;
 
-    
-	typedef DataItem<T> DataItemType;
-	typedef std::list<const DataItemType *> DataItemListType;
 
-	typedef CrossValidationFold<T> CrossValidationFoldType;
-	typedef std::list<CrossValidationFoldType> CrossValidationFoldListType;
+    typedef DataItem<T> DataItemType;
+    typedef std::list<const DataItemType *> DataItemListType;
+
+    typedef CrossValidationFold<T> CrossValidationFoldType;
+    typedef std::list<CrossValidationFoldType> CrossValidationFoldListType;
 
 
 
-	
-	%newobject Create;
-	static DataManager* Create(const RepresenterType*);
-	%newobject Load;
-	static DataManager* Load(RepresenterType* representer, const char* filename);
-		
-	void AddDataset(DatasetConstPointerType dataset, const std::string& URI);
-	unsigned GetNumberOfSamples() const;
 
-	void Save(const char* filename);
+    %newobject Create;
+    static DataManager* Create(const RepresenterType*);
+    %newobject Load;
+    static DataManager* Load(RepresenterType* representer, const char* filename);
 
-	
-	/** cross validation functionality */
-	CrossValidationFoldListType GetCrossValidationFolds(unsigned nFolds, bool randomize = true) const;
-	DataItemListType GetData() const;
-	
+    void AddDataset(DatasetConstPointerType dataset, const std::string& URI);
+    unsigned GetNumberOfSamples() const;
+
+    void Save(const char* filename);
+
+
+    /** cross validation functionality */
+    CrossValidationFoldListType GetCrossValidationFolds(unsigned nFolds, bool randomize = true) const;
+    DataItemListType GetData() const;
+
 private:
-	DataManager();
+    DataManager();
 };
 }
 %template(DataManager_vtkPD) statismo::DataManager<vtkPolyData>;
@@ -193,14 +192,14 @@ namespace statismo {
 template <typename T>
 class DataManagerWithSurrogates : public DataManager<T> {
 public:
-	typedef statismo::Representer<T> RepresenterType;
-	typedef RepresenterType::DatasetConstPointerType DatasetConstPointerType;
+    typedef statismo::Representer<T> RepresenterType;
+    typedef RepresenterType::DatasetConstPointerType DatasetConstPointerType;
 
-	static DataManagerWithSurrogates<T>* Create(const RepresenterType* representer, const std::string& surrogTypeFilename);
-	void AddDatasetWithSurrogates(DatasetConstPointerType datasetFilename, const std::string& surrogateFilename,  const std::string& surrogateFilename);
-		
+    static DataManagerWithSurrogates<T>* Create(const RepresenterType* representer, const std::string& surrogTypeFilename);
+    void AddDatasetWithSurrogates(DatasetConstPointerType datasetFilename, const std::string& surrogateFilename,  const std::string& surrogateFilename);
+
 private:
-	DataManagerWithSurrogates();
+    DataManagerWithSurrogates();
 };
 }
 
@@ -225,7 +224,7 @@ private:
 // Never got this to work properly. The wrapping of statismo::MatrixType is not sophisticated enough to work with the std::pair and list wrappers.
 
 //%template(PointValuePair_tvr) std::pair<TrivialVectorialRepresenter::PointType, TrivialVectorialRepresenter::ValueType>;
-//%template(PointValueWithCovariancePair_vtkPD) std::pair< std::pair< vtkPoint,vtkPoint >,statismo::MatrixType >; 
+//%template(PointValueWithCovariancePair_vtkPD) std::pair< std::pair< vtkPoint,vtkPoint >,statismo::MatrixType >;
 //%template(PointValueWithCovarianceList_vtkPD) std::list< std::pair< std::pair< vtkPoint,vtkPoint >,statismo::MatrixType > >;
 //%template(MatrixList) std::list<statismo::MatrixType>;
 //%template(MatrixMatrixPair) std::pair< statismo::MatrixType, statismo::MatrixType >;
@@ -238,41 +237,41 @@ private:
 // ModelInfo
 //////////////////////////////////////////////////////
 
-namespace statismo { 
+namespace statismo {
 
 class BuilderInfo {
 public:
-	typedef std::pair<std::string, std::string> KeyValuePair;
-	typedef std::list<KeyValuePair> KeyValueList;
-			
-	const KeyValueList& GetDataInfo() const;
-	const KeyValueList& GetParameterInfo() const;	
+    typedef std::pair<std::string, std::string> KeyValuePair;
+    typedef std::list<KeyValuePair> KeyValueList;
+
+    const KeyValueList& GetDataInfo() const;
+    const KeyValueList& GetParameterInfo() const;
 };
 
 class ModelInfo {
 public:
-	typedef std::vector<BuilderInfo> BuilderInfoList;
-	const statismo::MatrixType& GetScoresMatrix() const;
+    typedef std::vector<BuilderInfo> BuilderInfoList;
+    const statismo::MatrixType& GetScoresMatrix() const;
 
-	virtual void Save(const H5::CommonFG& publicFg) const;
-	virtual void Load(const H5::CommonFG& publicFg);			
-	BuilderInfoList GetBuilderInfoList() const ;
+    virtual void Save(const H5::CommonFG& publicFg) const;
+    virtual void Load(const H5::CommonFG& publicFg);
+    BuilderInfoList GetBuilderInfoList() const ;
 };
 }
-%template (KeyValuePair) std::pair<std::string, std::string>; 
+%template (KeyValuePair) std::pair<std::string, std::string>;
 %template(KeyValueList) std::list<std::pair<std::string, std::string> >;
 %template(BuilderInfoList) std::vector<statismo::BuilderInfo>;
 
 /////////////////////////////////////////////////////////////////
 // Domain
 /////////////////////////////////////////////////////////////////
-namespace statismo { 
+namespace statismo {
 template <typename PointType>
 class Domain {
 public:
-	typedef std::vector<PointType> DomainPointsListType;
-	const DomainPointsListType& GetDomainPoints() const;
-	const unsigned GetNumberOfPoints() const;
+    typedef std::vector<PointType> DomainPointsListType;
+    const DomainPointsListType& GetDomainPoints() const;
+    const unsigned GetNumberOfPoints() const;
 };
 }
 %template(DomainVtkPoint) statismo::Domain<statismo::vtkPoint>;
@@ -284,96 +283,86 @@ public:
 // StatisticalModel
 //////////////////////////////////////////////////////
 
-namespace statismo { 
+namespace statismo {
 template <class T>
 class StatisticalModel {
 public:
 
-	typedef Representer<T> RepresenterType ;
-	typedef typename RepresenterType::DatasetPointerType DatasetPointerType;
-	typedef typename RepresenterType::DatasetConstPointerType DatasetConstPointerType;
+    typedef Representer<T> RepresenterType ;
+    typedef typename RepresenterType::DatasetPointerType DatasetPointerType;
+    typedef typename RepresenterType::DatasetConstPointerType DatasetConstPointerType;
     typedef typename RepresenterType::ValueType ValueType;
-	typedef typename RepresenterType::PointType PointType;
+    typedef typename RepresenterType::PointType PointType;
 
 
-	typedef Domain<PointType> DomainType;
+    typedef Domain<PointType> DomainType;
 
-	typedef unsigned PointIdType;
+    typedef unsigned PointIdType;
 
 
-	//typedef  PointValuePair<Representer>  PointValuePairType;
-	typedef std::pair<PointType, ValueType> PointValuePairType;
-	typedef std::pair<unsigned, ValueType> PointIdValuePairType;
-	typedef std::list<PointValuePairType> PointValueListType;
-	typedef std::list<PointIdValuePairType> PointIdValueListType;
-	
-	%newobject Create;
-     static StatisticalModel* Create(const RepresenterType* representer,     								 
-									 const statismo::VectorType& m,
-									 const statismo::MatrixType& orthonormalPCABasis,
-									 const statismo::VectorType& pcaVariance,
-									 double noiseVariance);
+    //typedef  PointValuePair<Representer>  PointValuePairType;
+    typedef std::pair<PointType, ValueType> PointValuePairType;
+    typedef std::pair<unsigned, ValueType> PointIdValuePairType;
+    typedef std::list<PointValuePairType> PointValueListType;
+    typedef std::list<PointIdValuePairType> PointIdValueListType;
+
+    %newobject Create;
+     static StatisticalModel* Create(const RepresenterType* representer,
+                                     const statismo::VectorType& m,
+                                     const statismo::MatrixType& orthonormalPCABasis,
+                                     const statismo::VectorType& pcaVariance,
+                                     double noiseVariance);
      virtual ~StatisticalModel();
-	 
 
-     %newobject Load(RepresenterType* representer, const std::string& filename, unsigned numComponents=10000);
-     static StatisticalModel* Load(RepresenterType* representer, const std::string& filename, unsigned numComponents=10000);
-
-     
- 
-     
-	 void Save(const std::string& filename);
-	 void Save(const H5::Group& modelroot);
-
-	const RepresenterType* GetRepresenter() const;
-	const DomainType& GetDomain() const;
+    const RepresenterType* GetRepresenter() const;
+    const DomainType& GetDomain() const;
 
 
 
-	 ValueType EvaluateSampleAtPoint(DatasetConstPointerType sample, const PointType& point) const;
-	 DatasetPointerType DrawMean() const;	
-	 ValueType DrawMeanAtPoint(const PointType& pt) const;
-	 %rename("DrawMeanAtPointId") DrawMeanAtPoint(unsigned) const;
-	 ValueType DrawMeanAtPoint(unsigned ptId) const;
+     ValueType EvaluateSampleAtPoint(DatasetConstPointerType sample, const PointType& point) const;
+     DatasetPointerType DrawMean() const;
+     ValueType DrawMeanAtPoint(const PointType& pt) const;
+     %rename("DrawMeanAtPointId") DrawMeanAtPoint(unsigned) const;
+     ValueType DrawMeanAtPoint(unsigned ptId) const;
 
-	 %rename("DrawRandomSample") DrawSample() const;	 
-	 DatasetPointerType DrawSample() const;	  
-	 DatasetPointerType DrawSample(const statismo::VectorType& coeffs) const;
-	 ValueType DrawSampleAtPoint(const statismo::VectorType& coeffs, const PointType& pt) const;	 
-	 %rename("DrawSampleAtPointId") DrawSampleAtPoint(const statismo::VectorType&, unsigned) const;
-	 ValueType DrawSampleAtPoint(const statismo::VectorType& coeffs, unsigned ptId) const;
+     %rename("DrawRandomSample") DrawSample() const;
+     DatasetPointerType DrawSample() const;
+     DatasetPointerType DrawSample(const statismo::VectorType& coeffs) const;
+     ValueType DrawSampleAtPoint(const statismo::VectorType& coeffs, const PointType& pt) const;
+     %rename("DrawSampleAtPointId") DrawSampleAtPoint(const statismo::VectorType&, unsigned) const;
+     ValueType DrawSampleAtPoint(const statismo::VectorType& coeffs, unsigned ptId) const;
 
        DatasetPointerType DrawPCABasisSample(unsigned componentNumber) const;
 
-	 
-	 statismo::VectorType ComputeCoefficients(DatasetConstPointerType ds) const;
-     statismo::VectorType ComputeCoefficientsForSampleVector(const statismo::VectorType& sample) const;
-	 statismo::VectorType ComputeCoefficientsForPointValues(const PointValueListType&  pointValues) const;
-	 statismo::VectorType ComputeCoefficientsForPointIDValues(const PointIdValueListType&  pointValues) const;
 
-	 double ComputeLogProbability(DatasetConstPointerType ds) const;
-	 double ComputeProbability(DatasetConstPointerType ds) const;
+     statismo::VectorType ComputeCoefficients(DatasetConstPointerType ds) const;
+     statismo::VectorType ComputeCoefficientsForSampleVector(const statismo::VectorType& sample) const;
+     statismo::VectorType ComputeCoefficientsForPointValues(const PointValueListType&  pointValues) const;
+     statismo::VectorType ComputeCoefficientsForPointIDValues(const PointIdValueListType&  pointValues) const;
+
+     double ComputeLogProbability(DatasetConstPointerType ds) const;
+     double ComputeProbability(DatasetConstPointerType ds) const;
          double ComputeMahalanobisDistance(DatasetConstPointerType ds) const;
 
-	 statismo::MatrixType GetCovarianceAtPoint(const PointType& pt1, const PointType& pt2) const;
-	 statismo::MatrixType GetCovarianceAtPoint(unsigned ptId1, unsigned ptId2) const;
+     statismo::MatrixType GetCovarianceAtPoint(const PointType& pt1, const PointType& pt2) const;
+     statismo::MatrixType GetCovarianceAtPoint(unsigned ptId1, unsigned ptId2) const;
 
-	 unsigned GetNumberOfPrincipalComponents();	 	
-	 statismo::VectorType DrawSampleVector(const statismo::VectorType& coefficients) const;
-	 const statismo::MatrixType& GetPCABasisMatrix() const ;
-	 const statismo::MatrixType GetOrthonormalPCABasisMatrix() const ;
-	 const statismo::VectorType& GetPCAVarianceVector() const;
-	 const statismo::VectorType& GetMeanVector() const;	 	 
+     unsigned GetNumberOfPrincipalComponents();
+     statismo::VectorType DrawSampleVector(const statismo::VectorType& coefficients) const;
+     const statismo::MatrixType& GetPCABasisMatrix() const ;
+     const statismo::MatrixType GetOrthonormalPCABasisMatrix() const ;
+     const statismo::VectorType& GetPCAVarianceVector() const;
+     const statismo::VectorType& GetMeanVector() const;
 
-	  const ModelInfo& GetModelInfo() const;
-	  void SetModelInfo(const ModelInfo& modelInfo);
-	double GetNoiseVariance() const;
-	
-	private:
-	StatisticalModel();
+      const ModelInfo& GetModelInfo() const;
+      void SetModelInfo(const ModelInfo& modelInfo);
+    double GetNoiseVariance() const;
+
+    private:
+    StatisticalModel();
 
 };
-} 
+}
 
 %template(StatisticalModel_vtkPD) statismo::StatisticalModel<vtkPolyData>;
 
@@ -382,24 +371,24 @@ public:
 //////////////////////////////////////////////////////
 
 
-namespace statismo { 
+namespace statismo {
 %newobject *::BuildNewModel;
 template <typename T>
 class PCAModelBuilder {
 public:
 
-	typedef ModelBuilder<T> Superclass;
-	typedef typename DataManager<T> DataManagerType;
-	typedef typename DataManagerType::DataItemListType DataItemListType;	
+    typedef ModelBuilder<T> Superclass;
+    typedef typename DataManager<T> DataManagerType;
+    typedef typename DataManagerType::DataItemListType DataItemListType;
 
         typedef enum { JacobiSVD, SelfAdjointEigenSolver } EigenValueMethod;
 
-	%newobject Create;
-	static PCAModelBuilder* Create();
-	
+    %newobject Create;
+    static PCAModelBuilder* Create();
+
          StatisticalModel<T>* BuildNewModel(const DataItemListType& sampleList, double noiseVariance, bool computeScores=true, EigenValueMethod method = JacobiSVD) const;
 private:
-	PCAModelBuilder();
+    PCAModelBuilder();
 
 };
 }
@@ -413,29 +402,29 @@ private:
 
 
 
-namespace statismo { 
+namespace statismo {
 %newobject *::BuildNewModelFromModel;
 %newobject *::BuildNewModel;
 
 template <typename T>
 class PosteriorModelBuilder {
-	typedef ModelBuilder<T> Superclass;
+    typedef ModelBuilder<T> Superclass;
 public:
-	typedef  DataManager<T> 				DataManagerType;
-	typedef typename DataManagerType::DataItemListType DataItemListType;		
-	typedef  StatisticalModel<T> 	StatisticalModelType;	
-	typedef typename StatisticalModelType::PointValueType PointValueType;
-	typedef  typename StatisticalModelType::PointValueListType PointValueListType;
-	
-	%newobject Create;
-	static PosteriorModelBuilder* Create();
-	virtual ~PosteriorModelBuilder();
+    typedef  DataManager<T>                 DataManagerType;
+    typedef typename DataManagerType::DataItemListType DataItemListType;
+    typedef  StatisticalModel<T>     StatisticalModelType;
+    typedef typename StatisticalModelType::PointValueType PointValueType;
+    typedef  typename StatisticalModelType::PointValueListType PointValueListType;
 
-	StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model,	const PointValueListType& pointValues,  double pointValuesNoiseVariance, bool computeScores=true) const;
-	StatisticalModelType* BuildNewModel(const DataItemListType& sampleList, const PointValueListType& pointValues,  double pointValuesNoiseVariance,	double noiseVariance) const;
+    %newobject Create;
+    static PosteriorModelBuilder* Create();
+    virtual ~PosteriorModelBuilder();
 
-	private:
-		PosteriorModelBuilder();
+    StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model,    const PointValueListType& pointValues,  double pointValuesNoiseVariance, bool computeScores=true) const;
+    StatisticalModelType* BuildNewModel(const DataItemListType& sampleList, const PointValueListType& pointValues,  double pointValuesNoiseVariance,    double noiseVariance) const;
+
+    private:
+        PosteriorModelBuilder();
 };
 }
 
@@ -448,28 +437,51 @@ public:
 // ReducedVarianceModelBuilder
 //////////////////////////////////////////////////////
 
-namespace statismo { 
+namespace statismo {
 %newobject *::BuildNewModelFromModel;
 
 template <typename Representer>
 class ReducedVarianceModelBuilder {
-	typedef ModelBuilder<Representer> Superclass;
-public:		
-	typedef  StatisticalModel<Representer> 	StatisticalModelType;	
-	
-	%newobject Create;
-	static ReducedVarianceModelBuilder* Create();
-	virtual ~ReducedVarianceModelBuilder();
+    typedef ModelBuilder<Representer> Superclass;
+public:
+    typedef  StatisticalModel<Representer>     StatisticalModelType;
+
+    %newobject Create;
+    static ReducedVarianceModelBuilder* Create();
+    virtual ~ReducedVarianceModelBuilder();
 
         StatisticalModelType* BuildNewModelWithLeadingComponents(const StatisticalModelType* model, unsigned numberOfLeadingComponents) const;
-        StatisticalModelType* BuildNewModelWithVariance(const StatisticalModelType* model,	double totalVariance) const;
-        StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model,	double totalVariance) const;
+        StatisticalModelType* BuildNewModelWithVariance(const StatisticalModelType* model,    double totalVariance) const;
+        // StatisticalModelType* BuildNewModelFromModel(const StatisticalModelType* model,    double totalVariance) const;
 
-	private:
-		ReducedVarianceModelBuilder();
+    private:
+        ReducedVarianceModelBuilder();
 };
 }
 
 %template(ReducedVarianceModelBuilder_vtkPD) statismo::ReducedVarianceModelBuilder<vtkPolyData>;
 
 
+//////////////////////////////////////////////////////
+// IO
+//////////////////////////////////////////////////////
+namespace statismo {
+template <typename T>
+class IO {
+private:
+    typedef StatisticalModel<T>  StatisticalModelType;
+    IO();
+public:
+
+    static StatisticalModelType* LoadStatisticalModel(
+        typename StatisticalModelType::RepresenterType *representer,
+        const std::string &filename,
+        unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max());
+    static StatisticalModelType* LoadStatisticalModel(
+        typename StatisticalModelType::RepresenterType *representer,
+        const H5::Group &modelRoot,
+        unsigned maxNumberOfPCAComponents = std::numeric_limits<unsigned>::max());
+    static void SaveStatisticalModel(const StatisticalModelType *const model, const std::string &filename);
+};
+}
+%template(IO_vtkPD) statismo::IO<vtkPolyData>;

--- a/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
@@ -46,19 +46,19 @@ import tempfile
 
 
 class Test(unittest.TestCase):
-    
+
     def setUp(self):
 
         self.datafiles = getDataFiles(DATADIR)
         ref = read_vtkpd(self.datafiles[0])
-        self.representer = statismo.vtkStandardMeshRepresenter.Create(ref)        
+        self.representer = statismo.vtkStandardMeshRepresenter.Create(ref)
         self.dataManager = statismo.DataManager_vtkPD.Create(self.representer)
-        
+
         datasets = map(read_vtkpd, self.datafiles)
-        for (dataset, filename) in zip(datasets, self.datafiles):        
+        for (dataset, filename) in zip(datasets, self.datafiles):
             self.dataManager.AddDataset(dataset, filename)
 
-        
+
     def tearDown(self):
         pass
 
@@ -68,85 +68,85 @@ class Test(unittest.TestCase):
             self.assertTrue(abs(pts1.GetPoint(i)[0] - pts2.GetPoint(i)[0]) <= max(sqrt(noise), 1e-2))
             self.assertTrue(abs(pts1.GetPoint(i)[1] - pts2.GetPoint(i)[1]) <= max(sqrt(noise), 1e-2))
             self.assertTrue(abs(pts1.GetPoint(i)[2] - pts2.GetPoint(i)[2]) <= max(sqrt(noise), 1e-2))
-        
+
     def buildAndTestPCAModel(self, noise):
         modelbuilder = statismo.PCAModelBuilder_vtkPD.Create()
-  
+
         model = modelbuilder.BuildNewModel(self.dataManager.GetData(), noise)
-                         
-        self.assertTrue(model.GetNumberOfPrincipalComponents() <= len(self.datafiles))        
-         
+
+        self.assertTrue(model.GetNumberOfPrincipalComponents() <= len(self.datafiles))
+
         # we cannot have negative eigenvalues
         self.assertTrue((model.GetPCAVarianceVector() >= 0).all() == True)
-        self.assertTrue(isnan(model.GetPCAVarianceVector()).any() == False) 
- 
+        self.assertTrue(isnan(model.GetPCAVarianceVector()).any() == False)
+
         # we project a dataset into the model and try to restore it.
-   
+
         samples = self.dataManager.GetData()
         sample = samples[0].GetSample()
         print sample.GetNumberOfPoints()
         coeffs_sample = model.ComputeCoefficients(sample)
         restored_sample = model.DrawSample(coeffs_sample)
- 
+
         self.assertEqual(sample.GetNumberOfPoints(), restored_sample.GetNumberOfPoints())
- 
+
         self.checkPointsAlmostEqual(sample.GetPoints(), restored_sample.GetPoints(), 100, noise)
- 
+
         # check if the scores can be used to restore the data in the datamanager
         scores = model.GetModelInfo().GetScoresMatrix()
         for i in xrange(0, scores.shape[1]):
             sample_from_scores = model.DrawSample(scores[:,i])
             sample_from_dm = samples[i].GetSample()
- 
+
             self.checkPointsAlmostEqual(sample_from_scores.GetPoints(), sample_from_dm.GetPoints(), 100, noise)
         return model
- 
+
     def testBuildPCAModelWithoutScores(self):
-       
+
         # check if a model can be build when there are no scores
         modelbuilder = statismo.PCAModelBuilder_vtkPD.Create()
-  
+
         model = modelbuilder.BuildNewModel(self.dataManager.GetData(), 0, False)
-                         
-        self.assertTrue(model.GetNumberOfPrincipalComponents() <= len(self.datafiles))                
- 
+
+        self.assertTrue(model.GetNumberOfPrincipalComponents() <= len(self.datafiles))
+
         # we cannot have negative eigenvalues
         self.assertTrue((model.GetPCAVarianceVector() >= 0).all() == True)
-         
+
         # check if the scores can be used to restore the data in the datamanager
         scores = model.GetModelInfo().GetScoresMatrix()
         self.assertTrue (scores.shape[0] == 0 and scores.shape[1] == 0)
- 
- 
-         
- 
+
+
+
+
     def testBuildPCAModelZeroNoise(self):
         model = self.buildAndTestPCAModel(0)
         self.assertAlmostEqual(model.GetNoiseVariance(), 0)
-         
+
     def testBuildPCAModelNonZeroNoise(self):
         model = self.buildAndTestPCAModel(0.1)
         self.assertAlmostEqual(model.GetNoiseVariance(), 0.1)
-         
+
     def testBuildPCAModelWithLargeNoise(self):
         model = self.buildAndTestPCAModel(1000)
         self.assertAlmostEqual(model.GetNoiseVariance(), 1000)
 
-        
-        
+
+
     def testCheckPosteriorModelMean(self):
-        # if we fix many points to correspond to one of the samples, and build a 
+        # if we fix many points to correspond to one of the samples, and build a
         # partiallyfixed model, its mean should correspond to the sample
         nPointsFixed = 100
-        nPointsTest = 1000        
-        
-        sample = self.dataManager.GetData()[0].GetSample()        
+        nPointsTest = 1000
 
-        pvList = statismo.PointValueList_vtkPD()        
+        sample = self.dataManager.GetData()[0].GetSample()
+
+        pvList = statismo.PointValueList_vtkPD()
 
         reference = self.representer.GetReference()
         domainPoints = self.representer.GetDomain().GetDomainPoints()
-        
+
         for pt_id in xrange(0, len(domainPoints), len(domainPoints) / nPointsFixed):
             fixed_pt = domainPoints[pt_id]
             value = statismo.vtkPoint(*getPDPointWithId(sample, pt_id))
@@ -156,47 +156,47 @@ class Test(unittest.TestCase):
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
 
-        
+
         partial_mean = pf_model.DrawMean()
 
-        # now the sample that we used to fix the point should be similar to the mean. We test it by  
+        # now the sample that we used to fix the point should be similar to the mean. We test it by
         for pt_id in xrange(0, sample.GetNumberOfPoints(), sample.GetNumberOfPoints() / nPointsTest):
             mean_pt = getPDPointWithId(partial_mean, pt_id)
             sample_pt = getPDPointWithId(sample, pt_id)
-            self.assertAlmostEqual(mean_pt[0], sample_pt[0], 0) 
+            self.assertAlmostEqual(mean_pt[0], sample_pt[0], 0)
             self.assertAlmostEqual(mean_pt[1], sample_pt[1], 0)
             self.assertAlmostEqual(mean_pt[2], sample_pt[2], 0)
- 
-        
-    def testCheckPosteriorModelWithoutConstraints(self):
-        # if we fix no point, it should be the same as building a normal pca model                
 
-        pvList = statismo.PointValueList_vtkPD()        
-            
+
+    def testCheckPosteriorModelWithoutConstraints(self):
+        # if we fix no point, it should be the same as building a normal pca model
+
+        pvList = statismo.PointValueList_vtkPD()
+
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
 
         pcamodelbuilder = statismo.PCAModelBuilder_vtkPD.Create()
         pca_model = pcamodelbuilder.BuildNewModel(self.dataManager.GetData(), 0.1)
-        
+
         sample  =  self.dataManager.GetData()[0].GetSample()
         coeffs_pf_model = pf_model.ComputeCoefficients(sample)
         coeffs_pca_model =   pca_model.ComputeCoefficients(sample)
         for i in xrange(0, len(coeffs_pf_model)):
             # the sign is allowed to change
             self.assertAlmostEqual(abs(coeffs_pf_model[i]), abs(coeffs_pca_model[i]), 1)
-                
-    def testCheckPosteriorModelVariancePlausibility(self):         
+
+    def testCheckPosteriorModelVariancePlausibility(self):
         # checks whether with every added point, the variance is decreasing
-                       
+
         reference = self.representer.GetReference()
         sample  =  self.dataManager.GetData()[0].GetSample()
         num_points = sample.GetNumberOfPoints()
         pvList = statismo.PointValueList_vtkPD()
-        
+
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
-        total_var = pf_model.GetPCAVarianceVector().sum() 
+        total_var = pf_model.GetPCAVarianceVector().sum()
         for pt_id in xrange(0, num_points, num_points / 10):
             ref_pt = statismo.vtkPoint(*getPDPointWithId(reference, pt_id))
             pt = statismo.vtkPoint(*getPDPointWithId(sample, pt_id))
@@ -204,49 +204,49 @@ class Test(unittest.TestCase):
             pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
             pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
             total_sdev_prev = total_var
-            total_var = pf_model.GetPCAVarianceVector().sum() 
+            total_var = pf_model.GetPCAVarianceVector().sum()
             self.assertTrue(total_var < total_sdev_prev)
 
 
-    def testPosteriorModelPointStaysPut(self):         
+    def testPosteriorModelPointStaysPut(self):
         #Checks if a point that is fixed really stays where it was constrained to stay
-                       
+
         reference = self.representer.GetReference()
         sample  =  self.dataManager.GetData()[0].GetSample()
         pvList = statismo.PointValueList_vtkPD()
-                
+
         ref_pt = getPDPointWithId(reference, 0)
         fixedpt = getPDPointWithId(sample, 0)
         pvList.append(statismo.PointValuePair_vtkPD(statismo.vtkPoint(*ref_pt),  statismo.vtkPoint(*fixedpt)))
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.01, 0.01)
-        
+
         # check for some samples if the points stay put
-        coeffs1 = zeros(pf_model.GetNumberOfPrincipalComponents())        
+        coeffs1 = zeros(pf_model.GetNumberOfPrincipalComponents())
         coeffs1[1] = 3
         coeffs2 = zeros(pf_model.GetNumberOfPrincipalComponents())
-        coeffs2[0] = -3        
-        
+        coeffs2[0] = -3
+
         for coeffs in [coeffs1, coeffs2]:
             partiallyFixedSample = pf_model.DrawSample(coeffs)
             self.assertAlmostEqual(partiallyFixedSample.GetPoints().GetPoint(0)[0], fixedpt[0], 1)
             self.assertAlmostEqual(partiallyFixedSample.GetPoints().GetPoint(0)[1], fixedpt[1], 1)
             self.assertAlmostEqual(partiallyFixedSample.GetPoints().GetPoint(0)[2], fixedpt[2], 1)
-            
-            
+
+
     def testCheckPosteriorModelMean(self):
-        # if we fix many points to correspond to one of the samples, and build a 
+        # if we fix many points to correspond to one of the samples, and build a
         # Posterior model, its mean should correspond to the sample
         nPointsFixed = 100
-        nPointsTest = 1000        
-        
-        sample = self.dataManager.GetData()[0].GetSample()        
+        nPointsTest = 1000
 
-        pvList = statismo.PointValueList_vtkPD()        
+        sample = self.dataManager.GetData()[0].GetSample()
+
+        pvList = statismo.PointValueList_vtkPD()
 
         reference = self.representer.GetReference()
         domainPoints = self.representer.GetDomain().GetDomainPoints()
-        
+
         for pt_id in xrange(0, len(domainPoints), len(domainPoints) / nPointsFixed):
             fixed_pt = domainPoints[pt_id]
             value = statismo.vtkPoint(*getPDPointWithId(sample, pt_id))
@@ -256,47 +256,47 @@ class Test(unittest.TestCase):
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
 
-        
+
         partial_mean = pf_model.DrawMean()
 
-        # now the sample that we used to fix the point should be similar to the mean. We test it by  
+        # now the sample that we used to fix the point should be similar to the mean. We test it by
         for pt_id in xrange(0, sample.GetNumberOfPoints(), sample.GetNumberOfPoints() / nPointsTest):
             mean_pt = getPDPointWithId(partial_mean, pt_id)
             sample_pt = getPDPointWithId(sample, pt_id)
-            self.assertAlmostEqual(mean_pt[0], sample_pt[0], 0) 
+            self.assertAlmostEqual(mean_pt[0], sample_pt[0], 0)
             self.assertAlmostEqual(mean_pt[1], sample_pt[1], 0)
             self.assertAlmostEqual(mean_pt[2], sample_pt[2], 0)
- 
-        
-    def testCheckPosteriorModelWithoutConstraints(self):
-        # if we fix no point, it should be the same as building a normal pca model                
 
-        pvList = statismo.PointValueList_vtkPD()        
-            
+
+    def testCheckPosteriorModelWithoutConstraints(self):
+        # if we fix no point, it should be the same as building a normal pca model
+
+        pvList = statismo.PointValueList_vtkPD()
+
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
 
         pcamodelbuilder = statismo.PCAModelBuilder_vtkPD.Create()
         pca_model = pcamodelbuilder.BuildNewModel(self.dataManager.GetData(), 0.1)
-        
+
         sample  =  self.dataManager.GetData()[0].GetSample()
         coeffs_pf_model = pf_model.ComputeCoefficients(sample)
         coeffs_pca_model =   pca_model.ComputeCoefficients(sample)
         for i in xrange(0, len(coeffs_pf_model)):
             # the sign is allowed to change
             self.assertAlmostEqual(abs(coeffs_pf_model[i]), abs(coeffs_pca_model[i]), 1)
-                
-    def testCheckPosteriorModelVariancePlausibility(self):         
+
+    def testCheckPosteriorModelVariancePlausibility(self):
         # checks whether with every added point, the variance is decreasing
-                       
+
         reference = self.representer.GetReference()
         sample  =  self.dataManager.GetData()[0].GetSample()
         num_points = sample.GetNumberOfPoints()
         pvList = statismo.PointValueList_vtkPD()
-        
+
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
-        total_var = pf_model.GetPCAVarianceVector().sum() 
+        total_var = pf_model.GetPCAVarianceVector().sum()
         for pt_id in xrange(0, num_points, num_points / 10):
             ref_pt = statismo.vtkPoint(*getPDPointWithId(reference, pt_id))
             pt = statismo.vtkPoint(*getPDPointWithId(sample, pt_id))
@@ -304,90 +304,90 @@ class Test(unittest.TestCase):
             pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
             pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.1, 0.1)
             total_sdev_prev = total_var
-            total_var = pf_model.GetPCAVarianceVector().sum() 
+            total_var = pf_model.GetPCAVarianceVector().sum()
             self.assertTrue(total_var < total_sdev_prev)
 
 
-    def testPosteriorModelPointStaysPut(self):         
+    def testPosteriorModelPointStaysPut(self):
         #Checks if a point that is fixed really stays where it was constrained to stay
-                       
+
         reference = self.representer.GetReference()
         sample  =  self.dataManager.GetData()[0].GetSample()
         pvList = statismo.PointValueList_vtkPD()
-                
+
         ref_pt = getPDPointWithId(reference, 0)
         fixedpt = getPDPointWithId(sample, 0)
         pvList.append(statismo.PointValuePair_vtkPD(statismo.vtkPoint(*ref_pt),  statismo.vtkPoint(*fixedpt)))
         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetData(), pvList, 0.01, 0.01)
-        
+
         # check for some samples if the points stay put
-        coeffs1 = zeros(pf_model.GetNumberOfPrincipalComponents())        
+        coeffs1 = zeros(pf_model.GetNumberOfPrincipalComponents())
         coeffs1[1] = 3
         coeffs2 = zeros(pf_model.GetNumberOfPrincipalComponents())
-        coeffs2[0] = -3        
-        
+        coeffs2[0] = -3
+
         for coeffs in [coeffs1, coeffs2]:
             PosteriorSample = pf_model.DrawSample(coeffs)
             self.assertAlmostEqual(PosteriorSample.GetPoints().GetPoint(0)[0], fixedpt[0], 1)
             self.assertAlmostEqual(PosteriorSample.GetPoints().GetPoint(0)[1], fixedpt[1], 1)
-            self.assertAlmostEqual(PosteriorSample.GetPoints().GetPoint(0)[2], fixedpt[2], 1)            
-            
+            self.assertAlmostEqual(PosteriorSample.GetPoints().GetPoint(0)[2], fixedpt[2], 1)
+
 
 # Never got this to work, but I don't want to delete it just yet.
 
 #     def testCheckPosteriorModelMean(self):
-#         # if we fix many points to correspond to one of the samples, and build a 
+#         # if we fix many points to correspond to one of the samples, and build a
 #         # Posterior model, its mean should correspond to the sample
 #         nPointsFixed = 100
-#         nPointsTest = 1000        
-#         
-#         sample = self.dataManager.GetData()[0].GetSample()        
-# 
-#         pvcList = statismo.PointValueWithCovarianceList_vtkPD(nPointsFixed)        
+#         nPointsTest = 1000
+#
+#         sample = self.dataManager.GetData()[0].GetSample()
+#
+#         pvcList = statismo.PointValueWithCovarianceList_vtkPD(nPointsFixed)
 #         matrixMatrixList = statismo.MatrixMatrixPair
-# 
+#
 #         reference = self.representer.GetReference()
 #         domainPoints = self.representer.GetDomain().GetDomainPoints()
-#         
+#
 #         pointCovarianceMatrix = 0.1 * identity(3)
-#         
+#
 #         i = 0
 #         for pt_id in xrange(0, len(domainPoints), len(domainPoints) / nPointsFixed):
 #             fixed_pt = domainPoints[pt_id]
 #             value = statismo.vtkPoint(*getPDPointWithId(sample, pt_id))
 #             pointValue = statismo.PointValuePair_vtkPD(fixed_pt, value)
-#             
+#
 #             pointValueWithCovariance = statismo.PointValueWithCovariancePair_vtkPD()
-#             
+#
 #             pointValueWithCovariance.first = pointValue
 #             pointValueWithCovariance.second = pointCovarianceMatrix
-# 
-# 
+#
+#
 #             pvcList.append(pointValueWithCovariance)
-# 
-# 
+#
+#
 #         pfmodelbuilder = statismo.PosteriorModelBuilder_vtkPD.Create()
 #         pf_model = pfmodelbuilder.BuildNewModel(self.dataManager.GetSampleDataStructure(), pvcList, 0.1)
-# 
-#         
+#
+#
 #         partial_mean = pf_model.DrawMean()
-# 
-#         # now the sample that we used to fix the point should be similar to the mean. We test it by  
+#
+#         # now the sample that we used to fix the point should be similar to the mean. We test it by
 #         for pt_id in xrange(0, sample.GetNumberOfPoints(), sample.GetNumberOfPoints() / nPointsTest):
 #             mean_pt = getPDPointWithId(partial_mean, pt_id)
 #             sample_pt = getPDPointWithId(sample, pt_id)
-#             self.assertAlmostEqual(mean_pt[0], sample_pt[0], 0) 
+#             self.assertAlmostEqual(mean_pt[0], sample_pt[0], 0)
 #             self.assertAlmostEqual(mean_pt[1], sample_pt[1], 0)
 #             self.assertAlmostEqual(mean_pt[2], sample_pt[2], 0)
- 
-        
+
+
 
 
 
     def testReducedVarianceModelBuilderCorrectlyReducesTotalVariance(self):
         modelbuilder = statismo.PCAModelBuilder_vtkPD.Create()
- 
+
         model = modelbuilder.BuildNewModel(self.dataManager.GetData(), 0.)
         reducedVarianceModelBuilder = statismo.ReducedVarianceModelBuilder_vtkPD.Create()
 
@@ -396,18 +396,18 @@ class Test(unittest.TestCase):
         self.assertTrue(newModelWithNComponents.GetNumberOfPrincipalComponents() == ncomponentsToKeep)
 
         for percentOfTotalVar in [1.0, 0.9, 0.8, 0.7, 0.6, 0.4, 0.2, 0.1]:
-            reducedModel = reducedVarianceModelBuilder.BuildNewModelFromModel(model, percentOfTotalVar)
+            reducedModel = reducedVarianceModelBuilder.BuildNewModelWithVariance(model, percentOfTotalVar)
 
             # we keep at least the required percentage of total variance
             self.assertTrue(reducedModel.GetPCAVarianceVector().sum() / model.GetPCAVarianceVector().sum() >= percentOfTotalVar)
 
             # make sure that one component less would not reach the variance
             self.assertTrue(reducedModel.GetPCAVarianceVector()[0:-1].sum() / model.GetPCAVarianceVector().sum() < percentOfTotalVar)
-            
+
 
         # check that there is a reduction (though we cannot say how much, as the specified variance is a lower bound)
         reducedModel05 = reducedVarianceModelBuilder.BuildNewModelWithVariance(model, 0.5)
-        self.assertTrue(reducedModel05.GetPCAVarianceVector().sum() <= model.GetPCAVarianceVector().sum())        
+        self.assertTrue(reducedModel05.GetPCAVarianceVector().sum() <= model.GetPCAVarianceVector().sum())
 
 
     def testReducedVarianceModelBuilderHandlesModelWithoutScores(self):
@@ -428,8 +428,7 @@ class Test(unittest.TestCase):
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Test)
-            
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()
-

--- a/modules/VTK/wrapping/tests/statismoTests/TestStatisticalModel.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestStatisticalModel.py
@@ -47,7 +47,7 @@ import tempfile
 
 
 class Test(unittest.TestCase):
-    
+
     def setUp(self):
         self.model = buildPolyDataModel(DATADIR, 0)
 
@@ -62,98 +62,99 @@ class Test(unittest.TestCase):
 
 
     def testConversionFromSampleVectorToSample(self):
-        
+
         # check whether the mechanism for vectors is ok in the first place
         coeffs = zeros(self.model.GetNumberOfPrincipalComponents())
-        self.assertTrue((self.model.DrawSampleVector(coeffs) == self.model.GetMeanVector()).all() == True) 
+        self.assertTrue((self.model.DrawSampleVector(coeffs) == self.model.GetMeanVector()).all() == True)
 
         # now we check that after drawing a sample the equality still holds
         sample = self.model.DrawSample(coeffs)
         samplePts = sample.GetPoints()
         sampleVec = self.model.DrawSampleVector(coeffs)
-        for pt_id in xrange(0, sample.GetNumberOfPoints()):            
-            self.assertTrue(samplePts.GetPoint(pt_id)[0] == sampleVec[pt_id * 3] and 
+        for pt_id in xrange(0, sample.GetNumberOfPoints()):
+            self.assertTrue(samplePts.GetPoint(pt_id)[0] == sampleVec[pt_id * 3] and
                              samplePts.GetPoint(pt_id)[1] == sampleVec[pt_id * 3 + 1] and
-                             samplePts.GetPoint(pt_id)[2] == sampleVec[pt_id * 3 + 2])      
-            
+                             samplePts.GetPoint(pt_id)[2] == sampleVec[pt_id * 3 + 2])
+
 
     def testSampleEvaluationOk(self):
         # draw a sample and check if the point evaluated is the same as what would be obtained by drawing the smaple directly at the point
-          
+
         ptId = self.model.GetDomain().GetNumberOfPoints() / 2
         pt = self.model.GetDomain().GetDomainPoints()[ptId]
-          
-        sample = self.model.DrawMean()         
+
+        sample = self.model.DrawMean()
         pointSample = self.model.DrawMeanAtPoint(pt)
         pointSample2 = self.model.EvaluateSampleAtPoint(sample, pt)
-          
-        self.assertTrue(pointSample[0] == pointSample2[0] and 
+
+        self.assertTrue(pointSample[0] == pointSample2[0] and
                         pointSample[1] == pointSample2[1] and
                         pointSample[2] == pointSample2[2])
-          
-              
-    def testSampleEqualsSampleAtPoint(self): 
-        """ test for a number of points whether DrawSampleAtPoints yields the same  
+
+
+    def testSampleEqualsSampleAtPoint(self):
+        """ test for a number of points whether DrawSampleAtPoints yields the same
             values as DrawSample, evaluated at the given points"""
-                        
-        #choose arbitrary coefficients                       
+
+        #choose arbitrary coefficients
         coeffs = zeros(self.model.GetNumberOfPrincipalComponents())
         coeffs[0] = -1
         coeffs[1] = 1
-          
+
         sample = self.model.DrawSample(coeffs)
         num_pts = sample.GetNumberOfPoints()
-        pt_ids = xrange(0, num_pts, num_pts / 10)        
+        pt_ids = xrange(0, num_pts, num_pts / 10)
         for ptid in pt_ids:
             sampleAtPt = self.model.DrawSampleAtPointId(coeffs, ptid)
-            self.assertTrue(sampleAtPt[0] == sample.GetPoints().GetPoint(ptid)[0] and 
+            self.assertTrue(sampleAtPt[0] == sample.GetPoints().GetPoint(ptid)[0] and
                             sampleAtPt[1] == sample.GetPoints().GetPoint(ptid)[1] and
                             sampleAtPt[2] == sample.GetPoints().GetPoint(ptid)[2])
-              
-      
-      
+
+
+
     def testLoadSave(self):
         """ test whether saving and loading a model restores the model correctly """
         tmpfile = tempfile.mktemp(suffix="h5")
-        self.model.Save(tmpfile)
-           
+        statismo.IO_vtkPD.SaveStatisticalModel(self.model, tmpfile)
+
         representer = statismo.vtkStandardMeshRepresenter.Create()
-        newModel = statismo.StatisticalModel_vtkPD.Load(representer, tmpfile)
+        newModel = statismo.IO_vtkPD.LoadStatisticalModel(representer, tmpfile)
         self.assertTrue((self.model.GetPCAVarianceVector() == newModel.GetPCAVarianceVector()).all())
         self.assertTrue((self.model.GetMeanVector() == newModel.GetMeanVector()).all())
         P = self.model.GetPCABasisMatrix()
         PNew = newModel.GetPCABasisMatrix()
         self.assertTrue((abs(P - PNew) < 1e-5).all())
-        
-             
+
+
         # check model info
         scores = self.model.GetModelInfo().GetScoresMatrix()
         newScores = newModel.GetModelInfo().GetScoresMatrix()
-     
+
         builderInfoList = self.model.GetModelInfo().GetBuilderInfoList();
         newBuilderInfoList = self.model.GetModelInfo().GetBuilderInfoList();
         self.assertEqual(len(builderInfoList), len(newBuilderInfoList), 1)
-     
+
         di = builderInfoList[0].GetDataInfo() # there is only one list
         newDi = newBuilderInfoList[0].GetDataInfo() #there is only one list
         self.assertEqual(len(di), len(newDi))
-             
+
         for (sortedDi, sortedNewDi) in zip(sorted(di), sorted(newDi)):
             self.assertEqual(sortedDi[0], sortedNewDi[0])
             self.assertEqual(sortedDi[1], sortedNewDi[1])
-     
+
         pi = builderInfoList[0].GetParameterInfo()
         newPi = newBuilderInfoList[0].GetParameterInfo() #there is only one list
         self.assertEqual(len(pi), len(newPi))
-             
+
         for (sortedPi, sortedNewPi) in zip(sorted(pi), sorted(newPi)):
             self.assertEqual(sortedPi[0], sortedNewPi[0])
             self.assertEqual(sortedPi[1], sortedNewPi[1])
-             
+
         self.assertTrue(((scores - newScores) < 1e-3).all())
-      
+
         # now we test if loading with less parameters loads the right submatrix
-        newModelSub = statismo.StatisticalModel_vtkPD.Load(representer, tmpfile, 2)
+        newModelSub = statismo.IO_vtkPD.LoadStatisticalModel(representer, tmpfile, 2)
+
         self.assertEqual(newModelSub.GetNumberOfPrincipalComponents(), 2)
         self.assertTrue((newModelSub.GetPCAVarianceVector()[0:1] == self.model.GetPCAVarianceVector()[0:1]).all)
         self.assertTrue((abs(newModelSub.GetPCABasisMatrix()[:,0:1] - self.model.GetPCABasisMatrix()[:,0:1]) < 1e-3).all())
@@ -176,21 +177,21 @@ class Test(unittest.TestCase):
             self.assertTrue(p, pScipy)
 
     def testLogProbabilityOfDatasetPlausibility(self):
- 
+
         num_samples = 100
- 
+
         for i in xrange(0, num_samples):
             coeffs = randn(self.model.GetNumberOfPrincipalComponents())
             s = self.model.DrawSample(coeffs)
             p = self.model.ComputeProbability(s)
             lp = self.model.ComputeLogProbability(s)
             self.assertTrue(log(p) -lp < 0.05, "Log probability should roughtly equal the log of the probability")
-         
+
     def testMahalanobisDistanceComputation(self):
     	mean = self.model.DrawMean()
     	mdMean = self.model.ComputeMahalanobisDistance(mean)
     	self.assertEqual(mdMean, 0)
-         
+
     	coeffs = zeros(self.model.GetNumberOfPrincipalComponents())
     	coeffs[0] = 3
     	s = self.model.DrawSample(coeffs)
@@ -205,54 +206,54 @@ class Test(unittest.TestCase):
         computed_coeffs = self.model.ComputeCoefficients(s)
         diff = (coeffs - computed_coeffs)[:-1] # we ignore the last coefficient
         self.assertTrue((diff < 1e-3).all()) #don't make the threshold too small, as we are dealing with floats
-              
-              
+
+
     def testCoefficientsForPointValues(self):
         coeffs = randn(self.model.GetNumberOfPrincipalComponents())
         s = self.model.DrawSample(coeffs)
-                 
+
         num_pts = s.GetNumberOfPoints()
-        pt_ids = xrange(0, num_pts, num_pts / 500) 
-  
+        pt_ids = xrange(0, num_pts, num_pts / 500)
+
         pvList = statismo.PointValueList_vtkPD()
         pidVList = statismo.PointIdValueList_vtkPD()
         for pt_id in pt_ids:
-             
+
             # we create a list of fixed points once using the point id ....
-            val = statismo.vtkPoint(*getPDPointWithId(s, pt_id))            
+            val = statismo.vtkPoint(*getPDPointWithId(s, pt_id))
             pidVPair = statismo.PointIdValuePair_vtkPD(pt_id, val)
             pidVList.append(pidVPair)
-             
+
             # ... and once more with the points
             representer = self.model.GetRepresenter()
-            ref_pt = statismo.vtkPoint(*getPDPointWithId(representer.GetReference(), pt_id)) 
+            ref_pt = statismo.vtkPoint(*getPDPointWithId(representer.GetReference(), pt_id))
             pvPair = statismo.PointValuePair_vtkPD(ref_pt, val)
             pvList.append(pvPair)
-             
-        computed_coeffs_ptids = self.model.ComputeCoefficientsForPointIDValues(pidVList)                        
+
+        computed_coeffs_ptids = self.model.ComputeCoefficientsForPointIDValues(pidVList)
         computed_coeffs_pts = self.model.ComputeCoefficientsForPointValues(pvList)
-         
+
         # does the list with the point and the one with the point ids yield the same result
         self.assertTrue((computed_coeffs_ptids == computed_coeffs_pts).all())
- 
+
         # now compare it to the real coefficients
         diff = (coeffs - computed_coeffs_pts)[:-1] # we ignore the last coefficient
-        self.assertTrue((diff < 1e-3).all())                
-                         
-     
+        self.assertTrue((diff < 1e-3).all())
+
+
     def testInternalMatrixDimensionalities(self):
         representer = self.model.GetRepresenter()
         num_points = representer.GetReference().GetNumberOfPoints()
         dim = representer.GetDimensions()
         pcaBasisMatrix= self.model.GetPCABasisMatrix()
         self.assertEqual(pcaBasisMatrix.shape[0], num_points * dim )
-        self.assertEqual(pcaBasisMatrix.shape[1], self.model.GetNumberOfPrincipalComponents())   
-         
+        self.assertEqual(pcaBasisMatrix.shape[1], self.model.GetNumberOfPrincipalComponents())
+
         meanVec = self.model.GetMeanVector()
         self.assertEqual(meanVec.shape[0], num_points * dim)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(Test)
-                
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/modules/core/include/StatismoIO.h
+++ b/modules/core/include/StatismoIO.h
@@ -55,11 +55,12 @@ namespace statismo {
 template <typename T >
 class IO {
   private:
-    typedef StatisticalModel<T>  StatisticalModelType;
     //This class is made up of static methods only and as such the Constructor is private to prevent misunderstandings.
     IO() {}
 
   public:
+    typedef StatisticalModel<T>  StatisticalModelType;
+    
     /**
      * Returns a new statistical model, which is loaded from the given HDF5 file
      * \param filename The filename


### PR DESCRIPTION
This is the pull request to fix issue #263 that worked for the following setup:

- MacOS
- 10.11
- clang 8.0.0 (clang-800.0.42.1)
- cmake 3.10
- python 2.7.12
- vtk 7.1.0
- swig 3.0.10
  