### PR TITLE
Due to changes in ITK 4.12, itkImageFileReader needs to be explicitly…

### DIFF
--- a/modules/ITK/cli/statismo-build-shape-model.cxx
+++ b/modules/ITK/cli/statismo-build-shape-model.cxx
@@ -37,6 +37,7 @@
 #include <itkDataManager.h>
 #include <itkDirectory.h>
 #include <itkImage.h>
+#include <itkImageFileReader.h>
 #include <itkLandmarkBasedTransformInitializer.h>
 #include <itkMesh.h>
 #include <itkMeshFileReader.h>


### PR DESCRIPTION
when packaging statismo for the latest ubuntu, I realized that due to changes in ITK 4.12, the following include needs to be added.