### PR TITLE
Nj/improvements vtk python wrapping

### DIFF
--- a/modules/VTK/src/vtkStandardMeshRepresenter.cxx
+++ b/modules/VTK/src/vtkStandardMeshRepresenter.cxx
@@ -83,7 +83,6 @@ vtkStandardMeshRepresenter::Clone() const {
 
 void vtkStandardMeshRepresenter::Load(const H5::Group& fg) {
     vtkPolyData* ref = 0;
-
     std::string repName = HDF5Utils::readStringAttribute(fg, "name");
     if (repName == "vtkPolyDataRepresenter" || repName == "itkMeshRepresenter") {
         ref = LoadRefLegacy(fg);
@@ -96,7 +95,6 @@ void vtkStandardMeshRepresenter::Load(const H5::Group& fg) {
 
 
 vtkPolyData* vtkStandardMeshRepresenter::LoadRef(const H5::Group& fg) const {
-
     statismo::MatrixType vertexMat;
     HDF5Utils::readMatrix(fg, "./points", vertexMat);
 
@@ -173,7 +171,6 @@ vtkPolyData* vtkStandardMeshRepresenter::LoadRef(const H5::Group& fg) const {
 
 vtkPolyData* vtkStandardMeshRepresenter::LoadRefLegacy(const H5::Group& fg) const {
     std::string tmpfilename = statismo::Utils::CreateTmpName(".vtk");
-
     HDF5Utils::getFileFromHDF5(fg, "./reference", tmpfilename.c_str());
     vtkPolyData* pd = vtkPolyData::New();
     vtkPolyDataReader* reader = vtkPolyDataReader::New();
@@ -272,8 +269,8 @@ statismo::VectorType vtkStandardMeshRepresenter::PointToVector(const PointType& 
 
 statismo::VectorType vtkStandardMeshRepresenter::SampleToSampleVector(
     DatasetConstPointerType _sample) const {
-    assert(m_reference != 0);
 
+    assert(m_reference != 0);
     vtkPolyData* sample = const_cast<vtkPolyData*>(_sample);
 
     VectorType sampleVec = VectorType::Zero(
@@ -290,7 +287,6 @@ statismo::VectorType vtkStandardMeshRepresenter::SampleToSampleVector(
 
 vtkStandardMeshRepresenter::DatasetPointerType vtkStandardMeshRepresenter::SampleVectorToSample(
     const VectorType& sample) const {
-
     assert(m_reference != 0);
 
     vtkPolyData* reference = const_cast<vtkPolyData*>(m_reference);

--- a/modules/VTK/wrapping/CMakeLists.txt
+++ b/modules/VTK/wrapping/CMakeLists.txt
@@ -66,3 +66,23 @@ install( TARGETS _statismo_VTK
   LIBRARY DESTINATION ${INSTALL_LIB_DIR}
   ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
 )
+
+# Extract the python install directory.
+# Source: https://stackoverflow.com/a/40006251/3388962
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c
+        "from distutils import sysconfig as sc;\
+        print(sc.get_python_lib(prefix='', plat_specific=True))"
+    OUTPUT_VARIABLE PYTHON_SITE
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Create a __init__ file for the python module.
+file(WRITE "${swig_outdir}/__init__.py" "from statismo.statismo_VTK import *" )
+
+install( FILES
+  "${swig_outdir}/_statismo_VTK.so"
+  "${swig_outdir}/statismo_VTK.py"
+  "${swig_outdir}/__init__.py"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE}/statismo"
+  COMPONENT Development
+)

--- a/modules/VTK/wrapping/statismo.i
+++ b/modules/VTK/wrapping/statismo.i
@@ -426,8 +426,7 @@ public:
 //////////////////////////////////////////////////////
 
 namespace statismo {
-%newobject *::BuildNewZeroModel;
-//%newobject *::BuildNewModel;
+%newobject *::BuildNewZeroMeanModel;
 template<typename T>
 class LowRankGPModelBuilder {
     typedef ModelBuilder<T> Superclass;
@@ -435,7 +434,7 @@ public:
     typedef Representer<T>                            RepresenterType;
     typedef typename RepresenterType::PointType       PointType;
     typedef ModelBuilder<T>                           Superclass;
-    typedef typename Superclass::StatisticalModelType StatisticalModelType;
+    typedef StatisticalModel<T>                       StatisticalModelType;
     typedef Domain<PointType>                         DomainType;
     typedef typename DomainType::DomainPointsListType DomainPointsListType;
     typedef MatrixValuedKernel<PointType>             MatrixValuedKernelType;
@@ -445,7 +444,7 @@ public:
     virtual ~LowRankGPModelBuilder();
 
     StatisticalModelType* BuildNewZeroMeanModel(
-        const MatrixValuedKernelType* kernel,
+        const MatrixValuedKernelType& kernel,
         unsigned numComponents,
         unsigned numPointsForNystrom = 500) const;
  private:

--- a/modules/VTK/wrapping/statismoTypemaps.i
+++ b/modules/VTK/wrapping/statismoTypemaps.i
@@ -34,12 +34,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 #if defined(SWIGPYTHON)
 
 	%{
+    #include <iostream>
 	#include "vtkPythonUtil.h"
 	#include "vtkVersion.h"
+    #include "vtkKernels.h"
 #if (VTK_MAJOR_VERSION > 5 ||((VTK_MAJOR_VERSION == 5)&&(VTK_MINOR_VERSION > 6)))
 #define vtkPythonGetObjectFromPointer vtkPythonUtil::GetObjectFromPointer
 #define vtkPythonGetPointerFromObject vtkPythonUtil::GetPointerFromObject
@@ -51,21 +53,19 @@
 	%init %{
 	import_array();
 	%}
-		
-	
-	
+
 	%typemap (out) statismo::MatrixType
 	{
 		npy_intp dims[2];
 		dims[0] = $1.rows();
 		dims[1] = $1.cols();
-		PyObject* c = PyArray_SimpleNew(2, dims, NPY_FLOAT);		
+		PyObject* c = PyArray_SimpleNew(2, dims, NPY_FLOAT);
 		memcpy(PyArray_DATA(c), $1.data(), dims[0] * dims[1] * sizeof(float));
 		$result = c;
-		  
+
 	}
-	
-	
+
+
 	%typemap (out) statismo::MatrixType&
 	{
 		npy_intp dims[2];
@@ -81,13 +81,13 @@
     npy_intp dims[2];
     dims[0] = $1.rows();
     dims[1] = $1.cols();
-    PyObject* c = PyArray_SimpleNew(2, dims, NPY_FLOAT);    
+    PyObject* c = PyArray_SimpleNew(2, dims, NPY_FLOAT);
     memcpy(PyArray_DATA(c), $1.data(), dims[0] * dims[1] * sizeof(float));
     $result = c;
-      
+
   }
-  
-  
+
+
   %typemap (out) const statismo::MatrixType&
   {
     npy_intp dims[2];
@@ -98,21 +98,21 @@
     $result = c;
   }
 
-	
+
 	%typemap (out) statismo::VectorType&
 	{
 		npy_intp dims[1];
 		dims[0] = $1->rows();
-		$result= PyArray_SimpleNewFromData(1, dims, NPY_FLOAT, $1->data());  
+		$result= PyArray_SimpleNewFromData(1, dims, NPY_FLOAT, $1->data());
 	}
 
 	%typemap (out) statismo::VectorType
 	{
 		npy_intp dims[1];
 		dims[0] = $1.rows();
-		PyObject* c = PyArray_SimpleNew(1, dims, NPY_FLOAT);		
+		PyObject* c = PyArray_SimpleNew(1, dims, NPY_FLOAT);
 		memcpy(PyArray_DATA(c), $1.data(), dims[0] * sizeof(float));
-		$result= c;  
+		$result= c;
 	}
 
 
@@ -121,11 +121,11 @@
 		int is_new_object1 = 0;
 		PyArrayObject* array = (PyArrayObject*) PyArray_ContiguousFromObject($input, PyArray_DOUBLE, 1, 1);
 		unsigned dim = array->dimensions[0];
-		
+
                 statismo::VectorType* v = new statismo::VectorType(dim);
-		for (unsigned i = 0; i < dim; i++) { 
+		for (unsigned i = 0; i < dim; i++) {
 			(*v)(i) = (float) ((double*) array->data)[i];
-		}		 
+		}
 		$1= v ;
 	}
 
@@ -134,11 +134,11 @@
 		int is_new_object1 = 0;
 		PyArrayObject* array = (PyArrayObject*) PyArray_ContiguousFromObject($input, PyArray_DOUBLE, 1, 1);
 		unsigned dim = array->dimensions[0];
-		
+
                 statismo::VectorType* v = new statismo::VectorType(dim);
-		for (unsigned i = 0; i < dim; i++) { 
+		for (unsigned i = 0; i < dim; i++) {
 			(*v)(i) = (float) ((double*) array->data)[i];
-		}		 
+		}
 		$1= *v ;
 		delete v;
 	}
@@ -149,29 +149,29 @@
 		PyArrayObject* array = (PyArrayObject*) PyArray_ContiguousFromObject($input, PyArray_DOUBLE, 2, 2);
 		unsigned dim1 = array->dimensions[0];
 		unsigned dim2 = array->dimensions[1];
-		
+
 		statismo::MatrixType* m = new statismo::MatrixType(dim1, dim2);
-		for (unsigned i = 0; i < dim1; i++) { 
+		for (unsigned i = 0; i < dim1; i++) {
 			for (unsigned j = 0; j < dim2; j++) {
 				(*m)(i,j) = (float) ((double*) array->data)[i* dim2 + j];
 			}
-		}		 
+		}
 		$1= m ;
 	}
-	
+
   %typemap (in) (const statismo::MatrixType)
   {
     int is_new_object1 = 0;
     PyArrayObject* array = (PyArrayObject*) PyArray_ContiguousFromObject($input, PyArray_DOUBLE, 2, 2);
     unsigned dim1 = array->dimensions[0];
     unsigned dim2 = array->dimensions[1];
-    
+
     statismo::MatrixType* m = new statismo::MatrixType(dim1, dim2);
-    for (unsigned i = 0; i < dim1; i++) { 
+    for (unsigned i = 0; i < dim1; i++) {
       for (unsigned j = 0; j < dim2; j++) {
         (*m)(i,j) = (float) ((double*) array->data)[i* dim2 + j];
       }
-    }    
+    }
     $1= *m ;
     delete m;
   }
@@ -182,29 +182,29 @@
     PyArrayObject* array = (PyArrayObject*) PyArray_ContiguousFromObject($input, PyArray_DOUBLE, 2, 2);
     unsigned dim1 = array->dimensions[0];
     unsigned dim2 = array->dimensions[1];
-    
+
     statismo::MatrixType* m = new statismo::MatrixType(dim1, dim2);
-    for (unsigned i = 0; i < dim1; i++) { 
+    for (unsigned i = 0; i < dim1; i++) {
       for (unsigned j = 0; j < dim2; j++) {
         (*m)(i,j) = (float) ((double*) array->data)[i* dim2 + j];
       }
-    }    
+    }
     $1= m ;
   }
-  
+
   %typemap (in) (statismo::MatrixType)
   {
     int is_new_object1 = 0;
     PyArrayObject* array = (PyArrayObject*) PyArray_ContiguousFromObject($input, PyArray_DOUBLE, 2, 2);
     unsigned dim1 = array->dimensions[0];
     unsigned dim2 = array->dimensions[1];
-    
+
     statismo::MatrixType* m = new statismo::MatrixType(dim1, dim2);
-    for (unsigned i = 0; i < dim1; i++) { 
+    for (unsigned i = 0; i < dim1; i++) {
       for (unsigned j = 0; j < dim2; j++) {
         (*m)(i,j) = (float) ((double*) array->data)[i* dim2 + j];
       }
-    }    
+    }
     $1= *m ;
     delete m;
   }
@@ -227,10 +227,10 @@
         statismo::vtkPoint pt = $1;
     	PyTuple_SetItem($result,0,PyFloat_FromDouble(pt[0]));
     	PyTuple_SetItem($result,1,PyFloat_FromDouble(pt[1]));
-    	PyTuple_SetItem($result,2,PyFloat_FromDouble(pt[2]));            	
+    	PyTuple_SetItem($result,2,PyFloat_FromDouble(pt[2]));
 	}
 
-	
+
 	// convert vtkPolyData To Corresponding type
 	%typemap (in) vtkPolyData*
 	{
@@ -247,9 +247,9 @@
 	PyImport_ImportModule("vtk");
 	    $result =  vtkPythonGetObjectFromPointer((vtkPolyData*) $1);
 	}
-	
 
-	
+
+
 	// the typecheck is needed to disambiguate char* from vtkPolyData* in overloaded method
 	%typecheck(SWIG_TYPECHECK_POINTER) vtkPolyData * {
 	  vtkPolyData *ptr;
@@ -260,8 +260,8 @@
 	    $1 = 1;
 	  }
 	}
-	
-	
+
+
   // convert vtkUnstructuredGrid To Corresponding type
   %typemap (in) vtkUnstructuredGrid*
   {
@@ -278,9 +278,9 @@
   PyImport_ImportModule("vtk");
       $result =  vtkPythonGetObjectFromPointer((vtkUnstructuredGrid*) $1);
   }
-  
 
-  
+
+
   // the typecheck is needed to disambiguate char* from vtkUnstructuredGrid* in overloaded method
   %typecheck(SWIG_TYPECHECK_POINTER) vtkUnstructuredGrid * {
     vtkUnstructuredGrid *ptr;
@@ -291,8 +291,8 @@
       $1 = 1;
     }
   }
-  
-  	
+
+
 
 	// convert vtkStructuredPoints To Corresponding type
 	%typemap (in) vtkStructuredPoints*
@@ -308,8 +308,8 @@
 	{
 	PyImport_ImportModule("vtk");
 	    $result =  vtkPythonGetObjectFromPointer((vtkStructuredPoints*) $1);
-	}	
-	
+	}
+
 	// the typecheck is needed to disambiguate char* from vtkStructuredPoints* in overloaded method
 	%typecheck(SWIG_TYPECHECK_POINTER) vtkStructuredPoints * {
 	  vtkStructuredPoints *ptr;
@@ -320,9 +320,7 @@
 	    $1 = 1;
 	  }
 	}
-	
 
-	
 	// Grab a 3 element array as a Python 3-tuple
 	%typemap(in) double[3](double temp[3]) {   // temp[3] becomes a local variable
 	  if (PyTuple_Check($input)) {
@@ -340,4 +338,3 @@
 #else
   #warning no "in" typemap defined
 #endif
-

--- a/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
+++ b/modules/VTK/wrapping/tests/statismoTests/TestModelBuilders.py
@@ -422,8 +422,24 @@ class Test(unittest.TestCase):
         self.assertTrue(newModelWithNComponents.GetNumberOfPrincipalComponents() == ncomponentsToKeep)
         self.assertTrue(newModelWithNComponents.GetModelInfo().GetScoresMatrix().shape[0] == 0)
 
+    def testBuildZeroMeanModel(self):
+        # simple test to create a zero mean model (the test is rather slow)
+        sigma = 1.0
+        nPointsTest = 1000
 
-
+        gk = statismo.GaussianKernel(sigma)
+        mvgk = statismo.UncorrelatedMatrixValuedKernel_vtkPD(gk, self.representer.GetDimensions())
+        builder = statismo.LowRankGPModelBuilder_vtkPD.Create(self.representer)
+        model = builder.BuildNewZeroMeanModel(mvgk, 100)
+        # The mean model should match the input model.
+        mean = model.DrawMean()
+        ref = self.representer.GetReference()
+        for pt_id in xrange(0, mean.GetNumberOfPoints(), mean.GetNumberOfPoints() / nPointsTest):
+            mean_pt = getPDPointWithId(mean, pt_id)
+            ref_pt = getPDPointWithId(ref, pt_id)
+            self.assertAlmostEqual(mean_pt[0], ref_pt[0], 6)
+            self.assertAlmostEqual(mean_pt[1], ref_pt[1], 6)
+            self.assertAlmostEqual(mean_pt[2], ref_pt[2], 6)
 
 
 

--- a/modules/VTK/wrapping/vtkKernels.i
+++ b/modules/VTK/wrapping/vtkKernels.i
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the statismo library.
+ *
+ * Author: Marcel Luethi (marcel.luethi@unibas.ch)
+ *
+ * Copyright (c) 2011 University of Basel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the project's author nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+%{
+#include "vtkHelper.h"
+#include "vtkKernels.h"
+#include "CommonTypes.h"
+%}
+
+namespace statismo {
+
+/******************************************************************************/
+template<class TPoint>
+class ScalarValuedKernel {
+  public:
+    ScalarValuedKernel();
+    virtual ~ScalarValuedKernel();
+    virtual double operator()(const TPoint& x, const TPoint& y) const = 0;
+    virtual std::string GetKernelInfo() const = 0;
+};
+%template(ScalarValuedKernel_vtkPD) ScalarValuedKernel<vtkPoint>;
+
+/******************************************************************************/
+class GaussianKernel : public ScalarValuedKernel<vtkPoint> {
+  public:
+    typedef ScalarValuedKernel<vtkPoint> Super;
+    GaussianKernel(double sigma);
+    double operator()(const vtkPoint& x, const vtkPoint& y) const;
+    std::string GetKernelInfo() const;
+};
+
+/******************************************************************************/
+template<class TPoint>
+class MatrixValuedKernel {
+  public:
+    MatrixValuedKernel(unsigned dim);
+    virtual statismo::MatrixType operator()(const TPoint& x,
+                                            const TPoint& y) const = 0;
+    virtual unsigned GetDimension() const;
+    virtual ~MatrixValuedKernel();
+    virtual std::string GetKernelInfo() const = 0;
+};
+%template(MatrixValuedKernel_vtkPD) MatrixValuedKernel<vtkPoint>;
+
+/******************************************************************************/
+template<class TPoint>
+class UncorrelatedMatrixValuedKernel : public MatrixValuedKernel<vtkPoint> {
+    typedef MatrixValuedKernel<TPoint> Superclass;
+  public:
+    UncorrelatedMatrixValuedKernel(
+        const ScalarValuedKernel<TPoint>* scalarKernel,
+        unsigned dimension);
+    statismo::MatrixType operator()(const TPoint& x, const TPoint& y) const;
+    virtual ~UncorrelatedMatrixValuedKernel();
+    std::string GetKernelInfo() const;
+};
+//%template(UncorrelatedMatrixValuedKernel_vtkPD) statismo::UncorrelatedMatrixValuedKernel<statismo::RepresenterTraits<vtkPolyData>::PointType>;
+%template(UncorrelatedMatrixValuedKernel_vtkPD) UncorrelatedMatrixValuedKernel<vtkPoint>;
+
+} // namespace statismo


### PR DESCRIPTION
Added vtk wrapper for the LowRankdGPModelBuilder and other objects that are required for its interface. I added a test for that python wrapper. And I also added a custom install target for the statismo python package such that `make install` will create a subfolder lib/python<version>/site-packages/statismo. 